### PR TITLE
chore: reconcile main into dev — the #2398 sanitizer ReDoS hotfix

### DIFF
--- a/docker/base-image/agent_server/utils/credential_sanitizer.py
+++ b/docker/base-image/agent_server/utils/credential_sanitizer.py
@@ -140,14 +140,68 @@ _KV_LINE_RE = re.compile(r'(?<![^\s"\'=])([^\s"\'=]+)=(["\']?)([^\s"\']+)\2')
 # composed regex could start matching mid-token, so `DB_.*` redacted
 # `MY_DB_PASS=x`. Anchoring with \Z reproduces exactly that (a `fullmatch`
 # rewrite would silently redact LESS — a leak, not a speedup).
-_SENSITIVE_KEY_SUFFIX_RE = [
-    re.compile(r'(?:' + p + r')\Z', re.IGNORECASE) for p in SENSITIVE_VAR_PATTERNS
-]
+#
+# --- #2398: the same quadratic shape, one call deeper -----------------------
+# #1670 made the LINE scan linear (#1661) and left THIS test quadratic:
+# `re.search(r'(?:.*TOKEN.*)\Z', key)` retries the leading `.*` from every
+# offset, so cost is O(len(key)^2). Measured on 3.13: 4 KB key = 0.32s,
+# 44 KB key = 40s — for ONE key, per match, per line, on a thread holding the
+# GIL. A py-spy watchdog caught it 14 times across three agents, every dump on
+# this stack:
+#
+#     <genexpr> (credential_sanitizer.py)      <- the `any(...)` below
+#     _is_sensitive_kv_key
+#     _redact_kv_match  ->  sanitize_text  ->  sanitize_dict (recursive)
+#     sanitize_subprocess_line  ->  read_stdout  (headless_executor)
+#
+# The old docstring called `key` "a short KEY= name". It is not: the key is
+# whatever preceded an `=` in `_KV_LINE_RE`'s `([^\s"\'=]+)`, which is
+# UNBOUNDED — and the stack above reaches here from stream-json tool RESULTS
+# via recursive `sanitize_dict`, so multi-KB "keys" are the normal case rather
+# than an adversarial one. That wrong assumption is what made a quadratic test
+# look harmless.
+#
+# Every pattern is `.*LITERAL.*` or `LITERAL.*`, and under `.search()` with a
+# trailing `\Z` both mean exactly "the key CONTAINS this literal". So the test
+# is substring containment: linear, C-level, no backtracking, and byte-for-byte
+# the same verdicts (pinned against the old implementation as an oracle over
+# thousands of keys in tests/unit/test_2398_sanitizer_key_redos.py).
+#
+# The literals are DERIVED from the patterns rather than restated, and the
+# derivation REFUSES anything that is not a plain literal. A future pattern
+# needing real regex semantics therefore fails loudly at import instead of
+# being silently reduced to a check that redacts less — the guard #1670 should
+# have carried.
+def _literal_from_pattern(pattern: str) -> str:
+    body = pattern
+    if body.startswith(".*"):
+        body = body[2:]
+    if body.endswith(".*"):
+        body = body[:-2]
+    if not body or re.escape(body) != body:
+        raise ValueError(
+            f"sensitive-key pattern {pattern!r} is not a plain `.*LITERAL.*` / "
+            f"`LITERAL.*` form. #2398 replaced the quadratic regex test with "
+            f"substring containment; a pattern needing real regex semantics "
+            f"must be handled explicitly rather than silently reduced to "
+            f"{body!r}."
+        )
+    return body.upper()
+
+
+_SENSITIVE_KEY_LITERALS = tuple(
+    _literal_from_pattern(p) for p in SENSITIVE_VAR_PATTERNS
+)
 
 
 def _is_sensitive_kv_key(key: str) -> bool:
-    """True if `key` (a short `KEY=` name) names a credential."""
-    return any(r.search(key) for r in _SENSITIVE_KEY_SUFFIX_RE)
+    """True if `key` names a credential.
+
+    `key` is whatever preceded an `=` in the scanned text — NOT necessarily a
+    short env-var name (#2398). Containment, not regex: see the note above.
+    """
+    upper = key.upper()
+    return any(lit in upper for lit in _SENSITIVE_KEY_LITERALS)
 
 
 def _redact_kv_match(match: "re.Match") -> str:

--- a/docker/base-image/agent_server/utils/credential_sanitizer.py
+++ b/docker/base-image/agent_server/utils/credential_sanitizer.py
@@ -181,8 +181,25 @@ def _literal_from_pattern(pattern: str) -> str:
     body = pattern
     if body.startswith(".*"):
         body = body[2:]
-    if body.endswith(".*"):
-        body = body[:-2]
+    # The TRAILING `.*` is what makes containment equivalent, so its absence is
+    # refused rather than tolerated (self-review, second pass). Under
+    # `.search()` the old form was `(?:BODY)\Z` — anchored at the END — so a
+    # pattern with no trailing `.*` meant "the key ENDS WITH this", and
+    # containment is wider: a bare `TOKEN` would stop matching only `MYTOKEN`
+    # and start matching `TOKEN_SUFFIX` too. That direction redacts MORE, so it
+    # is not a leak — but this function exists to refuse SILENT changes of
+    # meaning, and accepting one would be the same internal inconsistency that
+    # produced #2398: a stated contract that no longer described the code
+    # beneath it.
+    if not body.endswith(".*"):
+        raise ValueError(
+            f"sensitive-key pattern {pattern!r} has no trailing `.*`, so it "
+            f"meant 'the key ENDS WITH {body!r}'. #2398's containment test is "
+            f"WIDER than that — it would also match keys carrying {body!r} in "
+            f"the middle. Write it as `{body}.*` if containment is what you "
+            f"want, or handle the suffix case explicitly."
+        )
+    body = body[:-2]
     # An explicit safe set, NOT `re.escape(body) != body`. That was the first
     # form and it is wrong in the dangerous direction for a module imported
     # everywhere: `re.escape` also escapes `-`, which is not a metacharacter

--- a/docker/base-image/agent_server/utils/credential_sanitizer.py
+++ b/docker/base-image/agent_server/utils/credential_sanitizer.py
@@ -172,13 +172,24 @@ _KV_LINE_RE = re.compile(r'(?<![^\s"\'=])([^\s"\'=]+)=(["\']?)([^\s"\']+)\2')
 # needing real regex semantics therefore fails loudly at import instead of
 # being silently reduced to a check that redacts less — the guard #1670 should
 # have carried.
+# Characters that carry no regex meaning, so a body made only of these is a
+# literal and containment is exactly equivalent to the old anchored search.
+_PLAIN_LITERAL_RE = re.compile(r'[A-Za-z0-9_-]+')
+
+
 def _literal_from_pattern(pattern: str) -> str:
     body = pattern
     if body.startswith(".*"):
         body = body[2:]
     if body.endswith(".*"):
         body = body[:-2]
-    if not body or re.escape(body) != body:
+    # An explicit safe set, NOT `re.escape(body) != body`. That was the first
+    # form and it is wrong in the dangerous direction for a module imported
+    # everywhere: `re.escape` also escapes `-`, which is not a metacharacter
+    # outside a character class — so adding a perfectly literal `.*API-KEY.*`
+    # would have raised at import and taken the whole process down at boot.
+    # `.` IS special, so `A.B` is still (correctly) refused.
+    if not body or not _PLAIN_LITERAL_RE.fullmatch(body):
         raise ValueError(
             f"sensitive-key pattern {pattern!r} is not a plain `.*LITERAL.*` / "
             f"`LITERAL.*` form. #2398 replaced the quadratic regex test with "

--- a/src/backend/utils/credential_sanitizer.py
+++ b/src/backend/utils/credential_sanitizer.py
@@ -81,14 +81,68 @@ _KV_LINE_RE = re.compile(r'(?<![^\s"\'=])([^\s"\'=]+)=(["\']?)([^\s"\']+)\2')
 # composed regex could start matching mid-token, so `DB_.*` redacted
 # `MY_DB_PASS=x`. Anchoring with \Z reproduces exactly that (a `fullmatch`
 # rewrite would silently redact LESS — a leak, not a speedup).
-_SENSITIVE_KEY_SUFFIX_RE = [
-    re.compile(r'(?:' + p + r')\Z', re.IGNORECASE) for p in SENSITIVE_KEY_PATTERNS
-]
+#
+# --- #2398: the same quadratic shape, one call deeper -----------------------
+# #1670 made the LINE scan linear (#1661) and left THIS test quadratic:
+# `re.search(r'(?:.*TOKEN.*)\Z', key)` retries the leading `.*` from every
+# offset, so cost is O(len(key)^2). Measured on 3.13: 4 KB key = 0.32s,
+# 44 KB key = 40s — for ONE key, per match, per line, on a thread holding the
+# GIL. A py-spy watchdog caught it 14 times across three agents, every dump on
+# this stack:
+#
+#     <genexpr> (credential_sanitizer.py)      <- the `any(...)` below
+#     _is_sensitive_kv_key
+#     _redact_kv_match  ->  sanitize_text  ->  sanitize_dict (recursive)
+#     sanitize_subprocess_line  ->  read_stdout  (headless_executor)
+#
+# The old docstring called `key` "a short KEY= name". It is not: the key is
+# whatever preceded an `=` in `_KV_LINE_RE`'s `([^\s"\'=]+)`, which is
+# UNBOUNDED — and the stack above reaches here from stream-json tool RESULTS
+# via recursive `sanitize_dict`, so multi-KB "keys" are the normal case rather
+# than an adversarial one. That wrong assumption is what made a quadratic test
+# look harmless.
+#
+# Every pattern is `.*LITERAL.*` or `LITERAL.*`, and under `.search()` with a
+# trailing `\Z` both mean exactly "the key CONTAINS this literal". So the test
+# is substring containment: linear, C-level, no backtracking, and byte-for-byte
+# the same verdicts (pinned against the old implementation as an oracle over
+# thousands of keys in tests/unit/test_2398_sanitizer_key_redos.py).
+#
+# The literals are DERIVED from the patterns rather than restated, and the
+# derivation REFUSES anything that is not a plain literal. A future pattern
+# needing real regex semantics therefore fails loudly at import instead of
+# being silently reduced to a check that redacts less — the guard #1670 should
+# have carried.
+def _literal_from_pattern(pattern: str) -> str:
+    body = pattern
+    if body.startswith(".*"):
+        body = body[2:]
+    if body.endswith(".*"):
+        body = body[:-2]
+    if not body or re.escape(body) != body:
+        raise ValueError(
+            f"sensitive-key pattern {pattern!r} is not a plain `.*LITERAL.*` / "
+            f"`LITERAL.*` form. #2398 replaced the quadratic regex test with "
+            f"substring containment; a pattern needing real regex semantics "
+            f"must be handled explicitly rather than silently reduced to "
+            f"{body!r}."
+        )
+    return body.upper()
+
+
+_SENSITIVE_KEY_LITERALS = tuple(
+    _literal_from_pattern(p) for p in SENSITIVE_KEY_PATTERNS
+)
 
 
 def _is_sensitive_kv_key(key: str) -> bool:
-    """True if `key` (a short `KEY=` name) names a credential."""
-    return any(r.search(key) for r in _SENSITIVE_KEY_SUFFIX_RE)
+    """True if `key` names a credential.
+
+    `key` is whatever preceded an `=` in the scanned text — NOT necessarily a
+    short env-var name (#2398). Containment, not regex: see the note above.
+    """
+    upper = key.upper()
+    return any(lit in upper for lit in _SENSITIVE_KEY_LITERALS)
 
 
 def _redact_kv_match(match: "re.Match") -> str:

--- a/src/backend/utils/credential_sanitizer.py
+++ b/src/backend/utils/credential_sanitizer.py
@@ -126,8 +126,25 @@ def _literal_from_pattern(pattern: str) -> str:
     body = pattern
     if body.startswith(".*"):
         body = body[2:]
-    if body.endswith(".*"):
-        body = body[:-2]
+    # The TRAILING `.*` is what makes containment equivalent, so its absence is
+    # refused rather than tolerated (self-review, second pass). Under
+    # `.search()` the old form was `(?:BODY)\Z` — anchored at the END — so a
+    # pattern with no trailing `.*` meant "the key ENDS WITH this", and
+    # containment is wider: a bare `TOKEN` would stop matching only `MYTOKEN`
+    # and start matching `TOKEN_SUFFIX` too. That direction redacts MORE, so it
+    # is not a leak — but this function exists to refuse SILENT changes of
+    # meaning, and accepting one would be the same internal inconsistency that
+    # produced #2398: a stated contract that no longer described the code
+    # beneath it.
+    if not body.endswith(".*"):
+        raise ValueError(
+            f"sensitive-key pattern {pattern!r} has no trailing `.*`, so it "
+            f"meant 'the key ENDS WITH {body!r}'. #2398's containment test is "
+            f"WIDER than that — it would also match keys carrying {body!r} in "
+            f"the middle. Write it as `{body}.*` if containment is what you "
+            f"want, or handle the suffix case explicitly."
+        )
+    body = body[:-2]
     # An explicit safe set, NOT `re.escape(body) != body`. That was the first
     # form and it is wrong in the dangerous direction for a module imported
     # everywhere: `re.escape` also escapes `-`, which is not a metacharacter

--- a/src/backend/utils/credential_sanitizer.py
+++ b/src/backend/utils/credential_sanitizer.py
@@ -54,7 +54,11 @@ SENSITIVE_KEY_PATTERNS = [
 
 # Compiled patterns
 _secret_value_re = [re.compile(p) for p in SECRET_VALUE_PATTERNS]
-_sensitive_key_re = [re.compile(p, re.IGNORECASE) for p in SENSITIVE_KEY_PATTERNS]
+# (#2398) The compiled `_sensitive_key_re` list lived here and is gone with
+# the quadratic test it fed — nothing referenced it any more. Leaving it
+# would have kept the removed regexes compiled and reachable by name, which
+# is exactly the artifact that let this bug survive #1670: something that
+# looks like the live check and is not.
 
 # --- #1661: linear KEY=value redaction -------------------------------------
 # The patterns above describe KEY NAMES (`.*TOKEN.*` means "a name containing
@@ -113,13 +117,24 @@ _KV_LINE_RE = re.compile(r'(?<![^\s"\'=])([^\s"\'=]+)=(["\']?)([^\s"\']+)\2')
 # needing real regex semantics therefore fails loudly at import instead of
 # being silently reduced to a check that redacts less — the guard #1670 should
 # have carried.
+# Characters that carry no regex meaning, so a body made only of these is a
+# literal and containment is exactly equivalent to the old anchored search.
+_PLAIN_LITERAL_RE = re.compile(r'[A-Za-z0-9_-]+')
+
+
 def _literal_from_pattern(pattern: str) -> str:
     body = pattern
     if body.startswith(".*"):
         body = body[2:]
     if body.endswith(".*"):
         body = body[:-2]
-    if not body or re.escape(body) != body:
+    # An explicit safe set, NOT `re.escape(body) != body`. That was the first
+    # form and it is wrong in the dangerous direction for a module imported
+    # everywhere: `re.escape` also escapes `-`, which is not a metacharacter
+    # outside a character class — so adding a perfectly literal `.*API-KEY.*`
+    # would have raised at import and taken the whole process down at boot.
+    # `.` IS special, so `A.B` is still (correctly) refused.
+    if not body or not _PLAIN_LITERAL_RE.fullmatch(body):
         raise ValueError(
             f"sensitive-key pattern {pattern!r} is not a plain `.*LITERAL.*` / "
             f"`LITERAL.*` form. #2398 replaced the quadratic regex test with "

--- a/tests/unit/test_2398_sanitizer_key_redos.py
+++ b/tests/unit/test_2398_sanitizer_key_redos.py
@@ -92,6 +92,20 @@ def test_a_long_kv_line_sanitizes_quickly_end_to_end():
     assert "abc123" not in out
 
 
+def test_a_hyphenated_literal_is_accepted():
+    """Caught in self-review. The guard's first form was
+    `re.escape(body) != body`, which ALSO escapes `-` — not a metacharacter
+    outside a character class. So adding a perfectly literal `.*API-KEY.*`
+    would have raised at import, and this module is imported everywhere: a
+    benign pattern addition would have crash-looped the platform at boot.
+
+    Fails in the loud direction rather than the silent one, but "loud" here
+    means "nothing starts".
+    """
+    assert _literal_from_pattern(r'.*API-KEY.*') == "API-KEY"
+    assert _literal_from_pattern(r'X-AUTH-TOKEN.*') == "X-AUTH-TOKEN"
+
+
 def test_a_pattern_that_is_not_a_plain_literal_fails_loudly():
     """The derivation is only safe while every pattern is `.*LITERAL.*`.
 
@@ -103,6 +117,12 @@ def test_a_pattern_that_is_not_a_plain_literal_fails_loudly():
         _literal_from_pattern(r'.*(TOKEN|SECRET).*')
     with pytest.raises(ValueError, match="not a plain"):
         _literal_from_pattern(r'.*.*')
+    # `.` IS special, so this stays refused — the guard narrowed to accept
+    # hyphens must not have gone on to accept real metacharacters.
+    with pytest.raises(ValueError, match="not a plain"):
+        _literal_from_pattern(r'.*A.B.*')
+    with pytest.raises(ValueError, match="not a plain"):
+        _literal_from_pattern(r'.*TOKEN+.*')
 
 
 def test_every_shipped_pattern_derives_a_literal():
@@ -130,3 +150,16 @@ def test_the_vendored_agent_copy_got_the_same_fix():
     )
     assert "_literal_from_pattern" in body
     assert "any(r.search(key) for r in" not in body
+
+
+def test_the_removed_quadratic_regexes_are_not_left_compiled():
+    """Self-review finding: `_sensitive_key_re` compiled the very patterns this
+    change stopped using, and nothing referenced it any more.
+
+    Dead code would be a style note anywhere else. Here it is the specific
+    artifact that let this bug survive #1670 — a module-level name that looks
+    like the live check and is not, sitting next to the one that is.
+    """
+    from utils import credential_sanitizer as mod
+    assert not hasattr(mod, "_sensitive_key_re")
+    assert not hasattr(mod, "_SENSITIVE_KEY_SUFFIX_RE")

--- a/tests/unit/test_2398_sanitizer_key_redos.py
+++ b/tests/unit/test_2398_sanitizer_key_redos.py
@@ -92,6 +92,30 @@ def test_a_long_kv_line_sanitizes_quickly_end_to_end():
     assert "abc123" not in out
 
 
+def test_a_pattern_with_no_trailing_wildcard_is_refused():
+    """Self-review, second pass. The guard validated the LITERAL but not the
+    FORM, so a bare `TOKEN` was accepted — and under `.search()` the old form
+    was `(?:TOKEN)\\Z`, i.e. "the key ENDS WITH token". Containment is wider:
+    `TOKEN_SUFFIX` was not sensitive and would have become sensitive.
+
+    Redacting more is not a leak, so this is not urgent. It is refused anyway
+    because this function's whole job is to refuse SILENT changes of meaning —
+    tolerating one here would be the same internal inconsistency that produced
+    #2398: a stated contract that no longer describes the code beneath it.
+
+    No shipped pattern is affected: all 13 backend and 30 agent patterns end
+    in `.*` (asserted below).
+    """
+    with pytest.raises(ValueError, match="no trailing"):
+        _literal_from_pattern(r'TOKEN')
+    with pytest.raises(ValueError, match="no trailing"):
+        _literal_from_pattern(r'.*TOKEN')
+
+
+def test_every_shipped_pattern_has_the_trailing_wildcard():
+    assert all(p.endswith(".*") for p in SENSITIVE_KEY_PATTERNS)
+
+
 def test_a_hyphenated_literal_is_accepted():
     """Caught in self-review. The guard's first form was
     `re.escape(body) != body`, which ALSO escapes `-` — not a metacharacter

--- a/tests/unit/test_2398_sanitizer_key_redos.py
+++ b/tests/unit/test_2398_sanitizer_key_redos.py
@@ -1,0 +1,132 @@
+"""#2398 — the credential-sanitizer KEY test must be linear, and unchanged.
+
+#1670 fixed the LINE scan (#1661) and left the KEY test quadratic one call
+deeper: `_is_sensitive_kv_key` ran `re.search(r'(?:.*TOKEN.*)\\Z', key)` per
+pattern, which retries `.*` from every offset — O(len(key)^2).
+
+Two facts made that lethal rather than theoretical:
+
+* the "key" is whatever preceded an `=` in `_KV_LINE_RE`'s `([^\\s"'=]+)`, which
+  is UNBOUNDED — a base64 blob or a tool-result payload arrives here as a
+  "key", not the short env-var name the docstring claimed;
+* measured on 3.13, a 44 KB key cost ~40 CPU-seconds for ONE key, per match,
+  per line.
+
+py-spy caught the burn 14 times across three agents (cmo, copywriter,
+cornelius), every dump on this stack.
+
+These tests pin BOTH halves: the verdicts must not move (a faster check that
+redacts less is a credential leak), and the cost must stay linear.
+"""
+import re
+import time
+
+import pytest
+
+from utils.credential_sanitizer import (
+    SENSITIVE_KEY_PATTERNS,
+    _SENSITIVE_KEY_LITERALS,
+    _is_sensitive_kv_key,
+    _literal_from_pattern,
+    sanitize_text,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _old_implementation(key: str) -> bool:
+    """The pre-#2398 test, verbatim, as the equivalence oracle."""
+    compiled = [
+        re.compile(r'(?:' + p + r')\Z', re.IGNORECASE) for p in SENSITIVE_KEY_PATTERNS
+    ]
+    return any(r.search(key) for r in compiled)
+
+
+@pytest.mark.parametrize("key", [
+    "ANTHROPIC_API_KEY", "MY_DB_PASSWORD", "github_token", "TRINITY_MCP_API_KEY",
+    "prefix_TOKEN_suffix", "tokEN", "AUTHORIZATION", "AWS_", "OPENAI_ORG",
+    # ...and the ones that must stay UNREDACTED
+    "PATH", "HOME", "MY_DB_PASS", "NOTASECRET", "x", "",
+])
+def test_verdicts_are_unchanged(key):
+    """A faster check that redacts LESS is a leak, not a speedup."""
+    assert _is_sensitive_kv_key(key) == _old_implementation(key), key
+
+
+def test_the_suffix_semantics_that_1670_preserved_still_hold():
+    """`DB_.*` redacting `MY_DB_PASS=x` was deliberate (#1670): a name pattern
+    matches a SUFFIX of the key, never only the whole key. Containment keeps
+    that — this pins it so a later `fullmatch` "simplification" cannot quietly
+    narrow the redaction."""
+    assert _is_sensitive_kv_key("MY_DB_PASSWORD")
+    assert _is_sensitive_kv_key("SOME_PREFIX_ANTHROPIC_API_KEY")
+
+
+def test_the_key_test_is_linear():
+    """The regression itself. Quadratic growth is what pegged the core.
+
+    Generous absolute bound so this cannot flake on a loaded runner: the old
+    implementation took ~40s at 44 KB, the new one ~0.4ms. Anything under a
+    second at 64 KB proves the shape changed.
+    """
+    key = "A" * 65536
+    started = time.perf_counter()
+    assert _is_sensitive_kv_key(key) is False
+    elapsed = time.perf_counter() - started
+    assert elapsed < 1.0, (
+        f"the key test took {elapsed:.2f}s on a 64 KB key — the quadratic "
+        f"backtracking of #2398 is back. It is reached from sanitize_text via "
+        f"an UNBOUNDED `([^\\s\"'=]+)=` capture, so this is not a synthetic input."
+    )
+
+
+def test_a_long_kv_line_sanitizes_quickly_end_to_end():
+    """Through the public entry point, on the shape the agents actually hit:
+    stream-json with a long unbroken token before an `=`."""
+    line = "prefix " + ("A" * 44000) + "=value TOKEN=abc123"
+    started = time.perf_counter()
+    out = sanitize_text(line)
+    elapsed = time.perf_counter() - started
+    assert elapsed < 2.0, f"sanitize_text took {elapsed:.2f}s on a 44 KB token"
+    # ...and it still did its job.
+    assert "abc123" not in out
+
+
+def test_a_pattern_that_is_not_a_plain_literal_fails_loudly():
+    """The derivation is only safe while every pattern is `.*LITERAL.*`.
+
+    A future entry needing real regex semantics must raise at import rather
+    than be silently reduced to a literal that matches less — the failure mode
+    would be a credential that stops being redacted, with no test going red.
+    """
+    with pytest.raises(ValueError, match="not a plain"):
+        _literal_from_pattern(r'.*(TOKEN|SECRET).*')
+    with pytest.raises(ValueError, match="not a plain"):
+        _literal_from_pattern(r'.*.*')
+
+
+def test_every_shipped_pattern_derives_a_literal():
+    assert len(_SENSITIVE_KEY_LITERALS) == len(SENSITIVE_KEY_PATTERNS)
+    assert all(lit and lit.isupper() for lit in _SENSITIVE_KEY_LITERALS)
+
+
+def test_the_vendored_agent_copy_got_the_same_fix():
+    """Invariant #5. The py-spy stacks are all in the AGENT-SERVER copy —
+    `agent_server/utils/credential_sanitizer.py` — so fixing only the backend
+    would have left every dumped burn exactly where it was.
+
+    The two files are vendored in SHAPE, not byte-identically: the agent list
+    is `SENSITIVE_VAR_PATTERNS` and carries 30 entries to the backend's 13. The
+    derivation is what is shared, which is why it is asserted here rather than
+    diffed.
+    """
+    from pathlib import Path
+    agent = Path(__file__).resolve().parents[2] / (
+        "docker/base-image/agent_server/utils/credential_sanitizer.py")
+    body = agent.read_text()
+    assert "_SENSITIVE_KEY_LITERALS" in body, (
+        "the agent-server copy still runs the quadratic regex test — that is "
+        "the copy every py-spy dump was taken in"
+    )
+    assert "_literal_from_pattern" in body
+    assert "any(r.search(key) for r in" not in body


### PR DESCRIPTION
Blocks the `v0.9.5-rc1` cut. Found by `/release` pre-flight, not by a report.

## What was wrong

`main` carries five commits that never came back to `dev`. Four of them are the `hotfix/2398-sanitizer-key-redos` merge (#2406), and `dev` does not have the fix:

```python
# dev   — O(len(key)²), retries the leading .* from every offset
return any(r.search(key) for r in _SENSITIVE_KEY_SUFFIX_RE)

# main  — containment
upper = key.upper()
return any(lit in upper for lit in _SENSITIVE_KEY_LITERALS)
```

`tests/unit/test_2398_sanitizer_key_redos.py` was absent from `dev` entirely.

Per the hotfix's own measurements: **0.32s at a 4 KB key, 40s at 44 KB, on a thread holding the GIL**, caught 14 times across three agents by a py-spy watchdog. `key` is whatever preceded an `=` in `_KV_LINE_RE`'s `([^\s"\'=]+)` — unbounded — and recursive `sanitize_dict` reaches it from stream-json tool results, so multi-KB keys are the ordinary case rather than an adversarial one. #2398 is still open at P1.

## Why it blocks the RC specifically

`v0.9.5-rc1` is cut off `dev`, and its images become the DigitalOcean Marketplace snapshot (#2281/#2471). Tagging as-is would have published a known, production-observed DoS in a public one-click image.

## Why a merge and not a cherry-pick

**Each branch had a sanitizer fix the other lacked.** `dev` has #2208's `sk-` family consolidation — one rule covering `sk-proj-`/`sk-ant-`/`sk-svcacct-` and whatever comes next; `main` reverted to three prefix-specific patterns, so a service-account key passes through it unredacted. `main` has #2398. Moving either fix alone would have traded one leak for another.

Both are present on both copies after the merge:

| file | `_SENSITIVE_KEY_LITERALS` | quadratic `_SENSITIVE_KEY_SUFFIX_RE` | `sk-` family |
|---|---|---|---|
| `src/backend/utils/credential_sanitizer.py` | 2 refs | **0** | present |
| `docker/base-image/agent_server/utils/…` | 2 refs | **0** | present |

## Conflict resolution

- **Both sanitizer copies auto-merged cleanly.** They are *not* byte-identical vendored twins — the Invariant #5 mirror set is `credential_paths` / `model_context` / `safe_yaml` / `mcp_validator` — so no parity obligation attaches and two independent merges are the correct outcome here. Checked rather than assumed, because "vendored copy" would have demanded the opposite treatment.
- **`src/backend/enterprise` → dev's pin (`90f2f2cb`)**, the only real conflict. Verified with `git merge-base --is-ancestor` that main's `2a5def35` is an ancestor and dev is 3 commits ahead; taking main's would have rolled the paid tree backwards.

## Verification

- **195 passed** across `test_2398_sanitizer_key_redos` + `test_2208_sanitizer_key_family` + `test_1661_sanitizer_linear` + `test_credential_sanitizer_{agent,backend}`.
- `scripts/ci/check_alembic_heads.py` → **50 revisions, 1 head (`0049_execution_turn_integrity`)**. A reconcile merge is exactly where #2361's version-line fork came from last time, so this is checked explicitly.
- The merge touched **no** migration on either track (`src/backend/migrations/`, `db/migrations.py` — empty diff vs `dev`).

**Merge commit, not squash** — a reconcile squashed loses the ancestry that stops the next reconcile re-conflicting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9bL6DZ8QVyrSvPybp5ZuK