### PR TITLE
fix(agent): make the wedge dump answer what the first capture could not (#2455)

### DIFF
--- a/docker/base-image/agent_server/main.py
+++ b/docker/base-image/agent_server/main.py
@@ -33,7 +33,10 @@ from .auto_sync import schedule_auto_sync_if_enabled
 from .heartbeat import schedule_heartbeat
 from .services.result_callback import schedule_pending_result_resend
 from .services.orphan_sweeper import schedule_orphan_sweeper
-from .utils.thread_diagnostics import enable as _enable_thread_diagnostics
+from .utils.thread_diagnostics import (
+    enable as _enable_thread_diagnostics,
+    schedule_loop_watchdog as _schedule_loop_watchdog,
+)
 from .services.pull_worker import (
     schedule_pull_workers,
     schedule_pending_pull_result_resend,
@@ -101,6 +104,15 @@ schedule_pending_result_resend(app)
 # scenario where Trinity-side CB termination skips drain_reader_threads
 # and subsequent tasks fast-fail before reaching the agent.
 schedule_orphan_sweeper(app)
+
+# #2455 (09-02 occurrence): the wedge is not a teardown artifact — the event
+# loop stopped completing requests ~10 min BEFORE claude finished and ~3h
+# before any drain branch could notice, while heartbeats kept the agent
+# looking healthy. A beat task + watchdog THREAD is the only vantage point
+# that can notice a wedged loop; past a 60s stall it dumps every thread's
+# stack and the loop's task await-chains, re-dumping every 5 min while the
+# stall persists, and logs the recovery that bounds the wedge window.
+_schedule_loop_watchdog(app)
 
 # #946 / #1081 Phase 2: agent-side pull worker pool. DEFAULT OFF — gated on the
 # per-agent TRINITY_PULL_MODE flag (allowlist-injected by the backend). When off

--- a/docker/base-image/agent_server/utils/thread_diagnostics.py
+++ b/docker/base-image/agent_server/utils/thread_diagnostics.py
@@ -16,6 +16,34 @@ issue asks for exactly this: *"worth capturing where the thread actually is
 (py-spy / faulthandler on a live occurrence) rather than assuming
 blocked-on-pipe."*
 
+WHAT THE FIRST FIELD CAPTURE TAUGHT (2026-09-02, issue comment). The v1 dump
+fired on a real wedge and came back with exactly two frames for MainThread —
+the wedged thread — and no async caller. Four defects, each fixed here:
+
+  1. **Frame-object racing truncates chains.** ``sys._current_frames()`` hands
+     back live frame objects; formatting them races the running thread, and on
+     CPython 3.11+ a frame that exits mid-format DETACHES its ``f_back`` — the
+     chain silently ends there. That is how a MainThread running a full event
+     loop dumped as two mutually-inconsistent frames. The authoritative stacks
+     now come from ``faulthandler.dump_traceback`` into a temp file — C-level,
+     per-thread-atomic, immune to both races — with the pretty Python sample
+     kept as the human-readable, thread-NAMED view.
+  2. **The async caller is structurally absent from every thread stack.** A
+     suspended awaiting coroutine is not on any thread's C stack, so even a
+     perfect thread dump cannot say WHICH task (the /api/task response? the
+     result callback?) owns the frame that is stuck in ``aclose``. A new
+     section walks the registered main loop's tasks and each task's
+     ``cr_await`` chain — names, files, lines; never values.
+  3. **One sample cannot tell a spin from a block.** Two samples, ~250 ms
+     apart, in one dump. Identical line = parked; moving line = looping.
+  4. **Emission time lied about capture time.** On 09-02 the dump *printed*
+     hours after the branch that called it (both appeared the second the loop
+     unwedged), so the sample instant was unknowable. Every dump now embeds
+     ``captured_at`` (and per-sample offsets), and the raw text is emitted via
+     ``os.write(2, …)`` FIRST — bypassing the logging module's handler locks
+     and any wedged Python-level machinery — before the structured logger copy
+     that Vector correlates.
+
 WHY NOT py-spy. It needs installing into a running production container, root
 or `SYS_PTRACE` (agents run non-root with `CAP_DROP: ALL`, Invariant #17), and a
 human present *while the wedge is live*. The wedge is rare, is noticed hours
@@ -24,32 +52,76 @@ is in the standard library, needs no privileges, and can fire the instant the
 code itself concludes a thread is stuck — which is the only moment guaranteed to
 be during the event.
 
-WHAT IT COSTS WHEN NOTHING IS WRONG. Nothing. `dump_all_threads` is called only
-from the already-exceptional stuck/leaked branches, and `enable()` installs
-signal handlers that fire on request or on a fatal signal. There is no polling,
-no timer, and no per-line work.
+THE LOOP WATCHDOG (this file's second job, same issue). The 09-02 capture also
+proved the wedge is not a teardown artifact: the event loop stopped completing
+HTTP requests ~10 minutes BEFORE claude finished and ~3h before any drain
+branch could notice, while heartbeats kept the agent looking healthy. The only
+component positioned to notice a wedged loop is a plain thread watching a beat
+the loop must keep. ``schedule_loop_watchdog`` runs one: an async task stamps a
+monotonic beat every few seconds; a daemon thread checks it, and past the stall
+threshold it dumps (rate-limited while the stall persists — the periodic dumps
+answer spin-vs-block over hours, and the FIRST one catches the onset stack, not
+the teardown) and logs the stall duration on recovery. Costs one 5s timer when
+healthy.
+
+WHAT IT COSTS WHEN NOTHING IS WRONG. A beat task waking every few seconds and
+a watchdog thread waking every few seconds to compare two floats. Dumps happen
+only from already-exceptional branches or a stalled loop.
 
 SAFETY. Output goes to the agent log via `logger`, never to a file the agent
-could read back and echo. Tracebacks name modules, functions and line numbers —
-never values — so this cannot surface a credential the way an argument dump
-would.
+could read back and echo. Tracebacks name modules, functions and line numbers
+— never values — so this cannot surface a credential the way an argument dump
+would. The async-task section prints code names and awaitable TYPE names only.
 """
 from __future__ import annotations
 
+import asyncio
+import datetime as _dt
 import faulthandler
 import logging
+import os
 import signal
 import sys
+import tempfile
 import threading
+import time
 import traceback
 
 logger = logging.getLogger(__name__)
 
 # Bound the emitted text. A wedged process can hold dozens of threads and the
 # agent log is shipped to Vector; a dump is diagnostic, not an archive.
+# Section order is by diagnostic value (faulthandler stacks, then async tasks,
+# then the two Python samples) so truncation eats the most redundant part.
 MAX_DUMP_CHARS = 60_000
 
+# Gap between the two Python-level samples inside one dump. Long enough that a
+# looping thread shows a different line, short enough to cost nothing on a
+# teardown path already minutes deep.
+SECOND_SAMPLE_DELAY_SECONDS = 0.25
+
+# Loop-watchdog cadence. The beat task stamps every BEAT; the watchdog thread
+# checks every CHECK; a lag past STALL_THRESHOLD is a stalled loop (60s is far
+# beyond any legitimate sync work the agent-server does on the loop); while the
+# stall persists it re-dumps every STALL_REDUMP so a multi-hour wedge yields a
+# bounded series of samples instead of one.
+BEAT_INTERVAL_SECONDS = 5.0
+WATCHDOG_CHECK_SECONDS = 5.0
+STALL_THRESHOLD_SECONDS = 60.0
+STALL_REDUMP_SECONDS = 300.0
+
 _enabled = False
+
+# The running event loop, registered at startup so dump_all_threads can walk
+# its tasks from ANY thread (the drain branches and the watchdog are threads).
+_main_loop: asyncio.AbstractEventLoop | None = None
+
+# Watchdog state. _beat_at is written by the beat task (loop thread) and read
+# by the watchdog thread — a float store is atomic under the GIL.
+_beat_at: float | None = None
+_watchdog_stop = threading.Event()
+_watchdog_thread: threading.Thread | None = None
+_beat_task_ref: list = []  # strong ref — the asyncio GC footgun
 
 
 def enable() -> None:
@@ -88,42 +160,278 @@ def enable() -> None:
         logger.warning("[Diagnostics] could not arm faulthandler: %s", e)
 
 
-def dump_all_threads(reason: str, *, context: str = "") -> str:
-    """Log every thread's stack, and return what was logged.
+def register_main_loop(loop: asyncio.AbstractEventLoop) -> None:
+    """Record the serving event loop so dumps can walk its tasks (#2455)."""
+    global _main_loop
+    _main_loop = loop
 
-    Uses ``sys._current_frames()`` rather than ``faulthandler.dump_traceback``
-    because faulthandler writes to a real file DESCRIPTOR — it rejects an
-    in-memory buffer with ``fileno`` — and the whole point here is to get the
-    stacks into the agent's own structured log, which Vector already ships, not
-    onto a raw stderr line nobody correlates with the execution. faulthandler
-    keeps the jobs it is actually good at: the fatal-signal handler and the
-    ``SIGUSR1`` on-demand dump in :func:`enable`, both of which target stderr.
 
-    Returns the text (rather than None) so a caller can attach it to a result
-    envelope, or a test can assert on it without parsing the log.
+# --------------------------------------------------------------------------- #
+# Dump sections
+# --------------------------------------------------------------------------- #
 
-    Never raises: this runs on the teardown path of an execution that has
-    already gone wrong, and a diagnostic that can break that path is worse than
-    no diagnostic.
+def _faulthandler_section() -> str:
+    """Authoritative per-thread stacks, captured at C level.
+
+    ``faulthandler.dump_traceback`` walks each thread's interpreter frame stack
+    without executing Python between capture and format, so it is immune to the
+    f_back-detach race that truncated the 09-02 MainThread dump to two frames.
+    It only takes a real file DESCRIPTOR, so it goes through a temp file that
+    is read straight back. Its output names threads by hex ident only, so an
+    ident→name map is prepended.
     """
     try:
-        frames = sys._current_frames()          # CPython; the agent runs CPython
-        by_ident = {t.ident: t for t in threading.enumerate()}
-        chunks = []
-        for ident, frame in frames.items():
-            t = by_ident.get(ident)
-            name = t.name if t is not None else "<unknown>"
-            daemon = t.daemon if t is not None else "?"
-            stack = "".join(traceback.format_stack(frame))
-            chunks.append(f"--- thread {name} (ident={ident}, daemon={daemon})\n{stack}")
-        text = "\n".join(chunks)
+        names = ", ".join(
+            f"{t.ident:#x}={t.name}" for t in threading.enumerate() if t.ident
+        )
+        with tempfile.TemporaryFile() as f:
+            faulthandler.dump_traceback(file=f, all_threads=True)
+            f.seek(0)
+            raw = f.read().decode("utf-8", errors="replace")
+        return f"thread idents: {names}\n{raw}"
+    except Exception as e:  # noqa: BLE001 — a section may fail, the dump must not
+        return f"<faulthandler capture failed: {type(e).__name__}>"
+
+
+def _awaitable_chain(obj, limit: int = 32) -> list[str]:
+    """Follow a task's coroutine down its await chain — names/lines only.
+
+    A suspended awaiter is on NO thread's stack, so this is the only way to
+    answer "which async caller owns the stuck frame". Frames are read
+    best-effort off a possibly-running coroutine; lines may lag by a tick.
+    """
+    hops: list[str] = []
+    seen: set[int] = set()
+    while obj is not None and len(hops) < limit and id(obj) not in seen:
+        seen.add(id(obj))
+        frame = (
+            getattr(obj, "cr_frame", None)
+            or getattr(obj, "gi_frame", None)
+            or getattr(obj, "ag_frame", None)
+        )
+        if frame is not None:
+            code = frame.f_code
+            hops.append(f"{code.co_filename}:{frame.f_lineno} in {code.co_name}")
+        else:
+            # A Future/Event/etc. at the end of the chain: its TYPE says what
+            # is being awaited on without echoing any value it carries.
+            hops.append(f"<awaiting {type(obj).__name__}>")
+        obj = (
+            getattr(obj, "cr_await", None)
+            or getattr(obj, "gi_yieldfrom", None)
+            or getattr(obj, "ag_await", None)
+        )
+    return hops
+
+
+def _async_tasks_section() -> str:
+    """Every task on the registered main loop, with its await chain."""
+    loop = _main_loop
+    if loop is None:
+        return "<no main loop registered>"
+    try:
+        tasks = asyncio.all_tasks(loop)
+    except Exception as e:  # noqa: BLE001 — WeakSet iteration can race
+        return f"<task enumeration failed: {type(e).__name__}>"
+    if not tasks:
+        return "<no pending tasks>"
+    chunks = []
+    for task in tasks:
+        try:
+            chain = _awaitable_chain(task.get_coro())
+            body = "\n".join(f"    {hop}" for hop in chain) or "    <no frame>"
+            chunks.append(f"  task {task.get_name()}:\n{body}")
+        except Exception as e:  # noqa: BLE001
+            chunks.append(f"  task <unreadable: {type(e).__name__}>")
+    return "\n".join(chunks)
+
+
+def _python_sample() -> str:
+    """One human-readable pass over ``sys._current_frames`` — thread names
+    included, but racy against running threads (see module docstring). The
+    faulthandler section is the authoritative copy."""
+    frames = sys._current_frames()          # CPython; the agent runs CPython
+    by_ident = {t.ident: t for t in threading.enumerate()}
+    chunks = []
+    for ident, frame in frames.items():
+        t = by_ident.get(ident)
+        name = t.name if t is not None else "<unknown>"
+        daemon = t.daemon if t is not None else "?"
+        stack = "".join(traceback.format_stack(frame))
+        chunks.append(f"--- thread {name} (ident={ident}, daemon={daemon})\n{stack}")
+    return "\n".join(chunks)
+
+
+def _raw_emit(text: str) -> None:
+    """Write straight to fd 2, bypassing the logging module entirely.
+
+    On 09-02 both dumps reached the log HOURS after their call sites ran —
+    something between the call and the record being written was wedged. An
+    ``os.write`` to stderr takes no Python-level lock and cannot be delayed by
+    a stuck handler; Vector ships stderr, so the evidence lands even when the
+    structured copy below is stuck behind the very wedge being reported.
+    """
+    try:
+        os.write(2, text.encode("utf-8", errors="replace"))
+    except Exception:  # noqa: BLE001 — best-effort by definition
+        pass
+
+
+def dump_all_threads(reason: str, *, context: str = "") -> str:
+    """Log every thread's stack plus the main loop's task chains; return it.
+
+    Layout, ordered by diagnostic value so the size bound truncates the most
+    redundant part first:
+
+      1. faulthandler stacks (C-atomic, full chains, ident-keyed)
+      2. async task await-chains (the caller no thread stack can show)
+      3. two Python samples ~250 ms apart (named threads; spin vs block)
+
+    ``captured_at`` is embedded because emission time has been observed to lag
+    capture by hours on a wedged process. Never raises: this runs on the
+    teardown path of an execution that has already gone wrong, and a diagnostic
+    that can break that path is worse than no diagnostic.
+    """
+    try:
+        captured_at = _dt.datetime.now(_dt.timezone.utc).isoformat()
+        t0 = time.monotonic()
+        fh = _faulthandler_section()
+        tasks = _async_tasks_section()
+        sample1 = _python_sample()
+        time.sleep(SECOND_SAMPLE_DELAY_SECONDS)
+        sample2 = _python_sample()
+        n_threads = threading.active_count()
+        text = (
+            f"captured_at={captured_at}\n"
+            f"== faulthandler stacks (authoritative) ==\n{fh}\n"
+            f"== async tasks on main loop ==\n{tasks}\n"
+            f"== python sample 1 (+0.00s) ==\n{sample1}\n"
+            f"== python sample 2 (+{time.monotonic() - t0:.2f}s) ==\n{sample2}"
+        )
         if len(text) > MAX_DUMP_CHARS:
             text = text[:MAX_DUMP_CHARS] + f"\n… truncated at {MAX_DUMP_CHARS} chars"
-        logger.error(
-            "[Diagnostics] THREAD DUMP — %s%s | %d thread(s)\n%s",
-            reason, f" | {context}" if context else "", len(frames), text,
+        header = (
+            f"[Diagnostics] THREAD DUMP — {reason}"
+            f"{' | ' + context if context else ''} | {n_threads} thread(s)\n"
         )
+        _raw_emit(header + text + "\n")
+        logger.error("%s%s", header, text)
         return text
     except Exception as e:  # noqa: BLE001
         logger.warning("[Diagnostics] thread dump failed (%s): %s", reason, e)
         return ""
+
+
+# --------------------------------------------------------------------------- #
+# Event-loop stall watchdog (#2455, 09-02 occurrence)
+# --------------------------------------------------------------------------- #
+
+def _stall_decision(
+    lag: float,
+    now: float,
+    stalled_since: float | None,
+    last_dump_at: float | None,
+    *,
+    threshold: float = STALL_THRESHOLD_SECONDS,
+    redump: float = STALL_REDUMP_SECONDS,
+):
+    """Pure decision core of the watchdog — returns (action, stalled_since,
+    last_dump_at). Actions: "none" | "dump" | "recovered"."""
+    if lag >= threshold:
+        if stalled_since is None:
+            return "dump", now - lag, now
+        if last_dump_at is None or now - last_dump_at >= redump:
+            return "dump", stalled_since, now
+        return "none", stalled_since, last_dump_at
+    if stalled_since is not None:
+        return "recovered", None, None
+    return "none", None, None
+
+
+def _run_watchdog(
+    stop: threading.Event,
+    *,
+    check: float = WATCHDOG_CHECK_SECONDS,
+    threshold: float = STALL_THRESHOLD_SECONDS,
+    redump: float = STALL_REDUMP_SECONDS,
+    dump_fn=None,
+) -> None:
+    """Thread body. Parameters are injectable for tests; production uses the
+    module constants."""
+    dump = dump_fn or dump_all_threads
+    stalled_since: float | None = None
+    last_dump_at: float | None = None
+    while not stop.wait(check):
+        beat = _beat_at
+        if beat is None:
+            continue
+        now = time.monotonic()
+        lag = now - beat
+        action, stalled_since, last_dump_at = _stall_decision(
+            lag, now, stalled_since, last_dump_at,
+            threshold=threshold, redump=redump,
+        )
+        if action == "dump":
+            # The stall itself is the headline — raw first (the loop being
+            # stalled is exactly the condition under which structured logging
+            # has been observed to wedge).
+            _raw_emit(
+                f"[Diagnostics] EVENT LOOP STALLED — no beat for {lag:.1f}s "
+                f"(threshold {threshold:.0f}s) — dumping (#2455)\n"
+            )
+            dump(
+                "event loop stalled — beat task has not run",
+                context=f"lag={lag:.1f}s threshold={threshold:.0f}s",
+            )
+        elif action == "recovered":
+            msg = (
+                "[Diagnostics] event loop RECOVERED after a stall (#2455) — "
+                "the beat is fresh again. The stall window bounds the wedge; "
+                "see the THREAD DUMPs emitted during it."
+            )
+            _raw_emit(msg + "\n")
+            logger.error(msg)
+
+
+async def _beat_loop() -> None:
+    global _beat_at
+    while True:
+        _beat_at = time.monotonic()
+        await asyncio.sleep(BEAT_INTERVAL_SECONDS)
+
+
+def schedule_loop_watchdog(app) -> None:
+    """Attach the loop-stall watchdog to the FastAPI app. Idempotent-ish (one
+    watchdog thread per process); never raises out of startup."""
+
+    @app.on_event("startup")
+    async def _start_loop_watchdog() -> None:  # pragma: no cover — wiring
+        global _watchdog_thread, _beat_at
+        try:
+            register_main_loop(asyncio.get_running_loop())
+            _beat_at = time.monotonic()
+            _beat_task_ref.append(asyncio.get_running_loop().create_task(_beat_loop()))
+            if _watchdog_thread is None or not _watchdog_thread.is_alive():
+                _watchdog_stop.clear()
+                _watchdog_thread = threading.Thread(
+                    target=_run_watchdog,
+                    args=(_watchdog_stop,),
+                    name="loop-watchdog",
+                    daemon=True,
+                )
+                _watchdog_thread.start()
+            logger.info(
+                "[Diagnostics] loop watchdog armed — a %.0fs event-loop stall "
+                "dumps all threads + task chains, re-dumps every %.0fs while "
+                "stalled (#2455)",
+                STALL_THRESHOLD_SECONDS, STALL_REDUMP_SECONDS,
+            )
+        except Exception as e:  # noqa: BLE001 — diagnostics must never break boot
+            logger.warning("[Diagnostics] could not arm loop watchdog: %s", e)
+
+    @app.on_event("shutdown")
+    async def _stop_loop_watchdog() -> None:  # pragma: no cover — wiring
+        _watchdog_stop.set()
+        for task in _beat_task_ref:
+            task.cancel()
+        _beat_task_ref.clear()

--- a/tests/unit/test_2455_wedge_observability.py
+++ b/tests/unit/test_2455_wedge_observability.py
@@ -1,0 +1,253 @@
+"""#2455 follow-up — what the first field capture (2026-09-02) demanded.
+
+The v1 dump fired on a real wedge and came back nearly useless in four ways,
+each recorded in the issue comment:
+
+  * MainThread — the wedged thread — dumped as TWO mutually-inconsistent
+    frames: ``sys._current_frames`` hands back live frames, and CPython 3.11+
+    detaches ``f_back`` when a racing frame exits, silently truncating chains.
+  * The async CALLER (which task owned the frame stuck in ``aclose``) is
+    structurally absent from every thread stack — suspended awaiters are on no
+    thread's C stack.
+  * One sample cannot tell a spin from a block.
+  * The dumps PRINTED hours after their call sites ran, so the sample instant
+    was unknowable.
+
+These tests pin the fixes: faulthandler-based full-chain stacks, an async-task
+await-chain section, dual samples, an embedded capture timestamp, a raw fd-2
+emission path — and the loop watchdog that notices the wedge in ~a minute
+instead of at the executor's outer timeout hours later.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_BASE = Path(__file__).resolve().parents[2] / "docker" / "base-image"
+if str(_BASE) not in sys.path:
+    sys.path.insert(0, str(_BASE))
+
+from agent_server.utils import thread_diagnostics as td  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# The dump answers the questions the 09-02 capture could not
+# --------------------------------------------------------------------------- #
+
+def test_the_dump_embeds_its_capture_instant():
+    """On 09-02 both dumps printed the second the loop unwedged — hours after
+    the branches that called them — so nobody could say WHEN the frames were
+    sampled. The timestamp must live in the dump text itself."""
+    text = td.dump_all_threads("capture-instant probe")
+    assert "captured_at=" in text
+
+
+def test_the_dump_takes_two_samples_so_spin_and_block_are_distinguishable():
+    text = td.dump_all_threads("dual-sample probe")
+    assert "python sample 1" in text
+    assert "python sample 2" in text
+
+
+def test_the_authoritative_stacks_come_from_faulthandler_with_full_chains():
+    """The two-frame MainThread truncation is a property of formatting live
+    frame objects. faulthandler walks the interpreter stack at C level; the
+    proof of a full chain is that the dump shows THIS test function — a caller
+    several frames above dump_all_threads — in the dumping thread's stack."""
+    text = td.dump_all_threads("faulthandler probe")
+    assert "faulthandler stacks" in text
+    assert "most recent call first" in text, "faulthandler output missing"
+    fh_section = text.split("== async tasks")[0]
+    assert "test_the_authoritative_stacks_come_from_faulthandler" in fh_section, (
+        "faulthandler section must carry the full call chain, not just the "
+        "innermost frames"
+    )
+
+
+def test_the_faulthandler_section_maps_idents_to_thread_names():
+    """faulthandler names threads by hex ident only; the map is what lets an
+    operator match a stack to `top -bH` output and to the Python samples."""
+    text = td.dump_all_threads("ident-map probe")
+    assert "thread idents:" in text
+    assert "MainThread" in text
+
+
+def test_the_dump_walks_the_main_loops_task_await_chains():
+    """The wedged frame's async CALLER — /api/task response vs result callback
+    vs something else — is on no thread's stack. Only the task await-chain can
+    name it; the 09-02 comment asks for exactly this."""
+    parked = threading.Event()      # signals the chain reached its await
+    release_holder: list = []
+    loop_holder: list = []
+
+    async def wedge_probe_inner(evt):
+        parked.set()
+        await evt.wait()
+
+    async def wedge_probe_outer(evt):
+        await wedge_probe_inner(evt)
+
+    def run_loop():
+        loop = asyncio.new_event_loop()
+        loop_holder.append(loop)
+        evt = asyncio.Event()
+        release_holder.append((loop, evt))
+        loop.create_task(wedge_probe_outer(evt), name="wedge-probe-task")
+        loop.run_forever()
+
+    t = threading.Thread(target=run_loop, daemon=True)
+    t.start()
+    assert parked.wait(5), "probe task never reached its await"
+    prev = td._main_loop
+    try:
+        td.register_main_loop(loop_holder[0])
+        text = td.dump_all_threads("async-chain probe")
+    finally:
+        td._main_loop = prev
+        loop, evt = release_holder[0]
+        loop.call_soon_threadsafe(evt.set)
+        loop.call_soon_threadsafe(loop.stop)
+        t.join(5)
+
+    assert "wedge-probe-task" in text, "the task must be named"
+    assert "in wedge_probe_outer" in text, "the OUTER caller is the answer"
+    assert "in wedge_probe_inner" in text, "the chain must be walked, not one frame"
+
+
+def test_the_task_section_degrades_honestly_without_a_registered_loop():
+    prev = td._main_loop
+    try:
+        td._main_loop = None
+        text = td.dump_all_threads("no-loop probe")
+    finally:
+        td._main_loop = prev
+    assert "<no main loop registered>" in text
+
+
+def test_the_await_chain_names_types_never_values():
+    """The chain may end on a Future/Event; printing its repr could echo a
+    result VALUE (canary G-04 class). Type name only."""
+    async def tail():
+        pass
+    coro = tail()
+    try:
+        hops = td._awaitable_chain(coro)
+    finally:
+        coro.close()
+    assert hops and "in tail" in hops[0]
+    src = (Path(td.__file__)).read_text()
+    assert "type(obj).__name__" in src, "chain must print awaitable TYPE, not repr"
+
+
+# --------------------------------------------------------------------------- #
+# The loop watchdog — noticing the wedge while it is happening
+# --------------------------------------------------------------------------- #
+
+def test_stall_decision_dumps_on_crossing_then_rate_limits_then_recovers():
+    th, rd = 60.0, 300.0
+    # healthy
+    action, since, last = td._stall_decision(3.0, 1000.0, None, None, threshold=th, redump=rd)
+    assert action == "none" and since is None
+    # crossing: dump, onset back-dated to the last beat
+    action, since, last = td._stall_decision(61.0, 1000.0, None, None, threshold=th, redump=rd)
+    assert action == "dump" and since == pytest.approx(939.0) and last == 1000.0
+    # still stalled, inside the redump window: quiet
+    action, since2, last2 = td._stall_decision(120.0, 1059.0, since, last, threshold=th, redump=rd)
+    assert action == "none" and since2 == since and last2 == last
+    # past the redump window: dump again
+    action, _, last3 = td._stall_decision(400.0, 1301.0, since, last, threshold=th, redump=rd)
+    assert action == "dump" and last3 == 1301.0
+    # beat resumes: recovery, state cleared
+    action, since4, last4 = td._stall_decision(2.0, 1400.0, since, last3, threshold=th, redump=rd)
+    assert action == "recovered" and since4 is None and last4 is None
+
+
+def test_the_watchdog_thread_fires_the_dump_on_a_stale_beat():
+    """End to end through the real thread body with injected cadence: a beat
+    that stops advancing must produce dumps — more than one, so a multi-hour
+    wedge yields a series (spin vs block over time), not a single sample."""
+    calls: list = []
+    stop = threading.Event()
+    prev_beat = td._beat_at
+    td._beat_at = time.monotonic() - 100.0     # loop "stalled" 100s ago
+    t = threading.Thread(
+        target=td._run_watchdog,
+        kwargs=dict(stop=stop, check=0.02, threshold=1.0, redump=0.05,
+                    dump_fn=lambda reason, context="": calls.append((reason, context))),
+        daemon=True,
+    )
+    try:
+        t.start()
+        deadline = time.monotonic() + 3.0
+        while len(calls) < 2 and time.monotonic() < deadline:
+            time.sleep(0.02)
+    finally:
+        stop.set()
+        t.join(3)
+        td._beat_at = prev_beat
+    assert len(calls) >= 2, "a persisting stall must re-dump, not fire once"
+    reason, context = calls[0]
+    assert "event loop stalled" in reason
+    assert "lag=" in context
+
+
+def test_the_watchdog_stays_quiet_while_the_beat_is_fresh():
+    calls: list = []
+    stop = threading.Event()
+    prev_beat = td._beat_at
+    td._beat_at = time.monotonic()
+    t = threading.Thread(
+        target=td._run_watchdog,
+        kwargs=dict(stop=stop, check=0.02, threshold=5.0, redump=0.05,
+                    dump_fn=lambda *a, **k: calls.append(a)),
+        daemon=True,
+    )
+    try:
+        t.start()
+        time.sleep(0.2)
+    finally:
+        stop.set()
+        t.join(3)
+        td._beat_at = prev_beat
+    assert calls == [], "a healthy loop must cost zero dumps"
+
+
+# --------------------------------------------------------------------------- #
+# Wiring + the emission path that cannot be delayed by the wedge
+# --------------------------------------------------------------------------- #
+
+def _src(rel: str) -> str:
+    return (_BASE / "agent_server" / rel).read_text()
+
+
+def test_the_agent_server_arms_the_loop_watchdog():
+    src = _src("main.py")
+    assert "_schedule_loop_watchdog(app)" in src
+
+
+def test_the_dump_emits_raw_to_fd2_before_the_structured_logger():
+    """On 09-02 the structured records surfaced ~2h late. os.write(2, …) takes
+    no Python-level lock; it must run FIRST so the evidence lands even when
+    logging is stuck behind the wedge being reported."""
+    src = _src("utils/thread_diagnostics.py")
+    body = src[src.index("def dump_all_threads"):]
+    assert body.index("_raw_emit(") < body.index("logger.error("), (
+        "raw fd-2 emission must precede the logger call"
+    )
+    assert "os.write(2" in src
+
+
+def test_section_order_puts_the_authoritative_stacks_first():
+    """Truncation cuts the tail; the faulthandler stacks and the task chains
+    are the parts three prior fixes were missing, so they must survive it."""
+    text = td.dump_all_threads("order probe")
+    fh = text.index("== faulthandler stacks")
+    tasks = text.index("== async tasks")
+    s1 = text.index("== python sample 1")
+    assert fh < tasks < s1


### PR DESCRIPTION
## Scope change: the root cause landed separately in #2398

This PR originally also carried a sanitizer fix. **That has been dropped** — #2398 fixed the same root cause (the quadratic `_is_sensitive_kv_key`, one call below the #1670 fix) and is now on `dev` via #2501, and its fix is strictly better than the one here was: it derives substring containment from the patterns and pins **verdict equivalence against the old implementation as an oracle over 17,172 keys**, where this PR had used a key-length bound. Its `tests/unit/test_2398_sanitizer_key_redos.py` also supersedes the test file this PR added, so both were removed rather than merged.

What remains is only the observability work, which is additive and does not overlap #2398.

## What this PR does

Follow-up to #2456, driven by the first field capture (issue comment, 2026-09-02). That dump fired on a real wedge and came back nearly useless in four recorded ways; each is fixed here, plus the detection gap the timeline exposed.

### Dump upgrades (`thread_diagnostics.py`)

| 09-02 defect | Fix |
|---|---|
| MainThread — the wedged thread — dumped as **2 mutually-inconsistent frames** | `sys._current_frames()` hands back live frame objects; formatting races the running thread, and CPython 3.11+ **detaches `f_back` when a racing frame exits** — the chain silently truncates. Authoritative stacks now come from `faulthandler.dump_traceback` into a temp file (C-level, per-thread-atomic, full chains) with an ident→name map; the Python sample is kept as the thread-named human view |
| The async **caller is structurally absent** ("whether this is the /api/task streaming response … or something else is not in the dump") | A suspended awaiter is on no thread's C stack. New section walks the registered main loop's tasks and each `cr_await` chain — task name + `file:line in fn` per hop, awaitable TYPE at the tail. Never values (G-04 class) |
| "It is **one sample point**" | Two Python samples ~250 ms apart — identical line = parked, moving line = looping |
| Both dumps **printed at 13:28** for branches that ran at ~11:40 — sample instant unknowable | `captured_at` embedded in the dump text, and the raw dump goes out via `os.write(2, …)` **before** the structured logger call, so a wedged logging pipeline cannot delay or time-shift the evidence |

### Loop watchdog (new)

The timeline's sharpest fact: the event loop stopped completing requests at **10:17** — ~10 min *before* claude finished, ~3h before any drain branch could notice — while heartbeats kept the agent looking "Up". No existing component can notice a wedged loop from inside it.

`schedule_loop_watchdog(app)`: an async task stamps a monotonic beat every 5s; a daemon thread checks it. Past a 60s stall it dumps (raw-first), **re-dumps every 5 min while the stall persists** — so a multi-hour wedge yields a series of samples starting at the **onset**, not the teardown — and logs the recovery that bounds the wedge window. Costs one 5s timer when healthy; the pure decision core (`_stall_decision`) is unit-tested exhaustively.

Worth keeping even though #2398 removed the known cause: this family has produced four fixes now (#728 pipe block, #1502 grandchild holder, #1661/#1670 line regex, #2398 key test), each after a period of guessing. #2398's own diagnosis came from a py-spy watchdog run by hand on production; this makes that evidence automatic and in-process.

## Tests

- `tests/unit/test_2455_wedge_observability.py` (12 tests): full-chain proof (the dump must show a caller several frames above `dump_all_threads`), await-chain walk through a real parked task on a real loop, capture-instant + dual-sample + section-order pins, raw-before-logger source pin, watchdog fires-on-stale / quiet-on-fresh / rate-limits, values-never-echoed pins.
- All 13 existing `test_2455_stuck_reader_diagnostics.py` tests pass unchanged.
- Green against the new base alongside #2398's suite: **50 passed**.

Requires an agent base-image rebuild to reach the fleet (same as #2456 and #2398).

Related to #2455.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLfHNPtB5UCMk4LonZiJux
