### PR TITLE
chore: reconcile main into dev (fast-uri 3.1.7, #2507 + #2508)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -437,9 +437,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "overrides": {
     "@modelcontextprotocol/sdk": "^1.26.0",
     "hono": ">=4.11.7",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.7",
     "@hono/node-server": "^1.19.13",
     "ip-address": ">=10.1.1",
     "qs": ">=6.15.2"

--- a/src/helper-mcp/package-lock.json
+++ b/src/helper-mcp/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "zod": "^3.24.1"
       },
       "bin": {
@@ -951,9 +951,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Two dependabot bumps merged straight to `main` — the established path for dependency PRs on this repo (12 prior, e.g. #2032 for the previous fast-uri bump). That left `main` holding two commits `dev` did not have, so the next release PR would have carried them as conflicts. This merges them back so `main ⊂ dev` again.

## What is in it

Merge commit only — nothing hand-edited.

| File | Change |
|---|---|
| `package.json` | `fast-uri` override `^3.1.5` → `^3.1.7` |
| `package-lock.json` | `fast-uri` 3.1.5 → 3.1.7 |
| `src/helper-mcp/package-lock.json` | `fast-uri` 3.1.5 → 3.1.7, plus the lock mirror of `@modelcontextprotocol/sdk` catching up to `^1.30.0` |

That last line is not a version bump. `src/helper-mcp/package.json` already pins `^1.30.0` and both branches already install `1.30.0`; only `dev`s lockfile mirror still said `^1.30.0`s predecessor. The merge takes `main`s corrected mirror, so the lockfile now agrees with the manifest it belongs to.

Submodule pointers (`.claude`, `src/backend/enterprise`) are untouched — merged with `submodule.recurse=false`.

## Verification

Merged with `--no-ff`, **zero conflicts**. Against `origin/dev` the whole diff is 3 files, +8/-8, and every substantive line is one of the three above.

Run on the merge result, not on either parent:

- `src/helper-mcp`: `npm ci` → `npm run build` (tsc clean) → `npm test` 26/26 pass
- root: `npm ci` clean
- `git merge-base --is-ancestor origin/main HEAD` → true

The one remaining `npm audit` finding (moderate, `qs`) is pre-existing on both branches and untouched here.

## Merging

Please **merge, do not squash** — squashing collapses the merge commit and `main` would read as un-reconciled again on the next cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRWTVnJVjydCyLxHE1bMvP