### PR TITLE
Extend /claim from the issue to the tree

### DIFF
--- a/.github/workflows/knos-claims.yml
+++ b/.github/workflows/knos-claims.yml
@@ -1,0 +1,17 @@
+name: Knos claims
+
+# Advisory only. This never fails a build: the check exits 0 on every path,
+# including when it finds a conflict and when it crashes.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  claims:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: drexthealpha/Knos/action@v0.1.4

--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -2,6 +2,14 @@
 
 <!-- Written by `knos export`. Commit this file. -->
 
+<!--
+Reading this file needs nothing installed: it is plain markdown, and a fresh
+clone picks it up as-is. The live claim/withhold server is a separate, optional
+step - `pip install knos` (Python 3.10+), which the MCP entry launches as
+`python -m knos.mcp`. Without it, everything below still reads normally.
+-->
+
+
 A second clone reads this on its first question — it is one of the decision
 records knos looks for. Nothing here is private: secrets and private paths
 never reach it.

--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -1,0 +1,24 @@
+# Decisions and current work
+
+<!-- Written by `knos export`. Commit this file. -->
+
+A second clone reads this on its first question — it is one of the decision
+records knos looks for. Nothing here is private: secrets and private paths
+never reach it.
+
+
+## Decisions
+
+- **public repository** — This is a public repo. No credentials, API keys, internal URLs or PII, even in comments. Use placeholders and review `git diff` before every commit.  _(AGENTS.md, CLAUDE.md)_
+- **enterprise designs stay private** — Public docs describe the open-core seam only, never the catalog of gated modules. New enterprise design goes in `trinity-enterprise/docs/`, not here. A CI grep-guard flags regressions.  _(CLAUDE.md)_
+- **long MCP calls go async** — Claude Code enforces a 60-second timeout on MCP HTTP tool calls, so long tasks call `chat_with_agent` with `async=true, parallel=true` and poll `get_execution_result`.  _(AGENTS.md)_
+- **key scope** — Agent-scoped keys see only their permitted agents; user-scoped keys see the owner's agents.  _(AGENTS.md)_
+- **new top-level backend module needs a Dockerfile entry** — `docker/backend/Dockerfile` copies top-level `src/backend/*.py` by explicit name, so a new top-level module must be added to the COPY list or it is silently dropped from the image and crashes on deploy.  _(CONTRIBUTING.md)_
+- **issues are claimed before work starts** — `/claim` assigns an issue, refuses if it is already assigned, and refuses anything still labelled `status-incubating`.  _(.github/workflows/claim.yml)_
+
+## Being worked on right now
+
+_Nothing claimed._
+
+---
+<sub>knos export. Claims lapse after 30 minutes.</sub>


### PR DESCRIPTION
`/claim` already gives this repo the right idea at the issue level — take it, refuse if someone holds it, refuse if it is still incubating. It stops where the issue stops. Two contributors claiming *different* issues that touch `src/backend/routers/` still collide, and nothing in the tree says so.

**What's in the PR**

- `.knos/decisions.md` — the same record one level down, at the file level. Seeded from this repo's own standing rules; every line cites where it came from (`AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `.github/workflows/claim.yml`). Plain markdown, it diffs in review, and nothing on your never-commit list is in it.
- `.github/workflows/knos-claims.yml` — comments on a PR when it touches work someone has claimed or contradicts a recorded decision.

**It cannot red your CI.** The check returns 0 on every path, including when it finds a conflict and when it throws. It comments; it never fails.

The `.knos/decisions.md` half stands alone — a fresh clone reads it with nothing installed, because it is plain markdown in the tree. If you want the record and not the workflow, drop the second file and the PR still does something.

**Disclosure:** I wrote Knos. I seeded the record from your docs rather than mine so it is checkable rather than promotional. Close it if a third-party check isn't wanted — `/claim` is a good design and this is only the file-level half of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)