### PR TITLE
fix(packer): make the DigitalOcean 1-Click bundle actually buildable (#2281)

### DIFF
--- a/packer/digitalocean/README.md
+++ b/packer/digitalocean/README.md
@@ -43,6 +43,44 @@ specific artifact.
 The build fails if DigitalOcean's own `99-img-check.sh` finds anything, so a
 snapshot is never created from a droplet that would be rejected at review.
 
+### If the build fails immediately with "invalid key identifiers"
+
+```
+Error creating droplet: POST .../v2/droplets: 422 ... 59080294 are invalid key
+identifiers for Droplet creation.
+```
+
+Pass a pre-existing key and it cannot happen at all:
+
+```bash
+doctl compute ssh-key import trinity-packer-build \
+  --public-key-file ~/.ssh/id_ed25519.pub --format ID --no-header
+packer build -var "image_tag=v0.9.5-rc2" \
+  -var "ssh_key_id=<that id>" \
+  -var "ssh_private_key_file=$HOME/.ssh/id_ed25519" \
+  trinity.pkr.hcl
+```
+
+This is a DigitalOcean API consistency window, not a fault in the template:
+left to itself Packer imports a temporary SSH key and creates the droplet in the
+very next call, and the new key id is not reliably resolvable that fast. It cost
+**4 of 5** creates during the first real build of this bundle, each failing in
+~7 seconds; the same import/create pair spaced one command apart succeeds every
+time. Supplying a key removes the window rather than retrying into it — nothing
+is created during the build.
+
+Each failed attempt **leaks the temporary key**, and Packer's own cleanup then
+404s on it, so reap any strays or they accumulate on the account:
+
+```bash
+doctl compute ssh-key list --format ID,Name --no-header \
+  | awk '$2 ~ /^packer-/ {print $1}' \
+  | xargs -r -n1 doctl compute ssh-key delete --force
+```
+
+Check `doctl compute droplet list` too — a failure later in the build can leave
+the build droplet running.
+
 ## Per-release update runbook
 
 1. Cut the Trinity release; confirm the `v*` tag published all five images and

--- a/packer/digitalocean/files/etc/systemd/system/trinity-docker-firewall.service
+++ b/packer/digitalocean/files/etc/systemd/system/trinity-docker-firewall.service
@@ -1,0 +1,23 @@
+[Unit]
+# Re-applies the DOCKER-USER DROP rules on every boot.
+#
+# This replaces iptables-persistent, which cannot be used here: `ufw` declares
+# `Breaks: iptables-persistent, netfilter-persistent` (unversioned), so apt
+# removes ufw to install it — and DigitalOcean's own img_check.sh calls
+# `ufw status` unconditionally on Ubuntu and warns "No firewall is configured"
+# when it is absent.
+#
+# It is also the more correct mechanism regardless of the conflict:
+# netfilter-persistent restores at boot with no ordering against docker.service,
+# and DOCKER-USER does not exist until Docker creates it.
+Description=Trinity: drop internet access to Docker-published container ports
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/opt/trinity-firstboot/docker-firewall.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/packer/digitalocean/files/opt/trinity-firstboot/docker-firewall.sh
+++ b/packer/digitalocean/files/opt/trinity-firstboot/docker-firewall.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Close the Docker/ufw gap. Run at first boot AND at every boot thereafter, via
+# trinity-docker-firewall.service.
+#
+# docker-compose.hosted.yml publishes 8000 (backend), 8080 (MCP), 8686 (Vector),
+# the OTel collector's four ports, and the frontend's own FRONTEND_PORT on
+# 0.0.0.0. Docker's iptables rules are consulted BEFORE ufw's chain, so those
+# ports are reachable from the internet on a droplet whose ufw says otherwise —
+# `ufw deny 8000` is silently inert.
+#
+# 8081 is the entry that matters most and was missing (#2281 review C1): it is
+# the SPA itself, moved off :80 so Caddy can own 80/443. Compose publishes it
+# with the short syntax `"${FRONTEND_PORT:-80}:8080"`, which binds 0.0.0.0 — so
+# without it the login page answers plain HTTP on http://<ip>:8081, past both the
+# TLS termination and the http->https redirect this whole image is built around.
+#
+# One variable feeds both the probe and the insert: two hand-maintained lists
+# that disagree means the -C probe never matches its own rule and every re-run
+# stacks another. tests/unit/test_2281_firstboot_port_exposure.py keeps this
+# list from drifting from what compose actually publishes.
+#
+# DOCKER-USER is the one chain Docker leaves for the operator and evaluates
+# first, so the drop belongs here. Everything a user needs is served by Caddy on
+# 80/443; the container ports stay reachable from the host (Caddy proxies
+# 127.0.0.1:8081) and from other containers, which is what the platform uses.
+set -euo pipefail
+
+# Packer/systemd both run this without a login shell; iptables lives in /usr/sbin.
+export PATH="/usr/local/sbin:/usr/sbin:/sbin:${PATH}"
+
+DROP_PORTS=8000,8080,8081,8686,4317,4318,8889,13133
+
+# Docker creates DOCKER-USER when it starts. The unit is ordered After=docker.service,
+# but ordering is not readiness, so wait briefly rather than racing it.
+for _ in $(seq 1 30); do
+    iptables -n -L DOCKER-USER >/dev/null 2>&1 && break
+    sleep 1
+done
+
+if ! iptables -C DOCKER-USER -i eth0 -p tcp -m multiport \
+       --dports "$DROP_PORTS" -j DROP 2>/dev/null; then
+    iptables -I DOCKER-USER -i eth0 -p tcp -m multiport \
+      --dports "$DROP_PORTS" -j DROP
+    echo "DOCKER-USER: dropped external access to ${DROP_PORTS}"
+else
+    echo "DOCKER-USER: rule already present for ${DROP_PORTS}"
+fi

--- a/packer/digitalocean/files/opt/trinity-firstboot/firstboot.sh
+++ b/packer/digitalocean/files/opt/trinity-firstboot/firstboot.sh
@@ -6,6 +6,13 @@
 # snapshot: the admin password, the droplet's own IP, the certificate.
 set -euo pipefail
 
+# Same exposure as 01-provision.sh: this script's load-bearing tools — iptables
+# and netfilter-persistent, which close the Docker-past-ufw gap — live in
+# /usr/sbin. cloud-init normally supplies a root PATH that covers them, but the
+# cost of not depending on that is one line, and the failure it prevents is the
+# container ports staying open to the internet.
+export PATH="/usr/local/sbin:/usr/sbin:/sbin:${PATH}"
+
 STATE_DIR=/etc/trinity
 CRED_FILE="${STATE_DIR}/admin-credentials"
 USER_SUPPLIED_PW="${STATE_DIR}/admin-password"

--- a/packer/digitalocean/files/opt/trinity-firstboot/firstboot.sh
+++ b/packer/digitalocean/files/opt/trinity-firstboot/firstboot.sh
@@ -44,7 +44,31 @@ if [ -s "$USER_SUPPLIED_PW" ]; then
     shred -u "$USER_SUPPLIED_PW" 2>/dev/null || rm -f "$USER_SUPPLIED_PW"
 fi
 if [ -z "${ADMIN_PASSWORD:-}" ]; then
-    ADMIN_PASSWORD="$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 24)"
+    # --- password-generation (behaviour-tested; see test_2281_firstboot_password) ---
+    # NOT `tr -dc ... </dev/urandom | head -c 24`. Under this script's own
+    # `set -o pipefail` that is fatal, every time: head closes the pipe after 24
+    # bytes, tr dies of SIGPIPE against an endless source, and the non-zero
+    # status propagates out of the command substitution, where `set -e` ends the
+    # script. First boot died on this line on the very first droplet ever created
+    # from the snapshot — three lines in, before it had written anything but its
+    # own header, leaving a droplet with no Trinity, no certificate and no
+    # password.
+    #
+    # Reading a bounded chunk first means nothing closes a pipe early: head takes
+    # 1024 bytes and exits, tr drains all of them and exits 0. LC_ALL=C keeps tr
+    # byte-oriented rather than trusting the ambient locale to tolerate random
+    # bytes.
+    _pw_raw="$(head -c 1024 /dev/urandom | LC_ALL=C tr -dc 'A-Za-z0-9')"
+    ADMIN_PASSWORD="${_pw_raw:0:24}"
+    # 1024 random bytes yield ~635 alphanumerics on average, so this cannot
+    # plausibly fail — but it is a credential, and a short one must never be
+    # written rather than silently accepted.
+    if [ "${#ADMIN_PASSWORD}" -ne 24 ]; then
+        echo "FATAL: could not generate a 24-character admin password." >&2
+        exit 1
+    fi
+    unset _pw_raw
+    # --- end password-generation ---
 fi
 
 # The MOTD never echoes a password the operator chose — they already have it,

--- a/packer/digitalocean/files/opt/trinity-firstboot/firstboot.sh
+++ b/packer/digitalocean/files/opt/trinity-firstboot/firstboot.sh
@@ -109,46 +109,21 @@ set_env TRINITY_INSTALL_SOURCE do-marketplace
 chmod 0600 .env
 
 # --- 4. Close the Docker/ufw gap --------------------------------------------
-# docker-compose.hosted.yml publishes 8000 (backend), 8080 (MCP), 8686 (Vector),
-# the OTel collector's four ports, and the frontend's own FRONTEND_PORT on
-# 0.0.0.0. Docker's iptables rules are consulted BEFORE ufw's chain, so those
-# ports are reachable from the internet on a droplet whose ufw says otherwise —
-# `ufw deny 8000` is silently inert.
-#
-# 8081 is the entry that matters most and was missing (#2281 review C1): it is
-# the SPA itself, moved off :80 in step 3 so Caddy can own 80/443. Compose
-# publishes it with the short syntax `"${FRONTEND_PORT:-80}:8080"`, which binds
-# 0.0.0.0 — so without it the login page answers plain HTTP on
-# http://<ip>:8081, past both the TLS termination and the http→https redirect
-# this whole image is built around.
-#
-# One variable feeds both the probe and the insert: two hand-maintained lists
-# that disagree means the -C probe never matches its own rule and every re-run
-# stacks another. tests/unit/test_2281_firstboot_port_exposure.py keeps this
-# list from drifting from what compose actually publishes.
-#
-# DOCKER-USER is the one chain Docker leaves for the operator and evaluates
-# first, so the drop belongs here. Everything a user needs is served by Caddy on
-# 80/443; the container ports stay reachable from the host (Caddy proxies
-# 127.0.0.1:8081) and from other containers, which is what the platform uses.
-DROP_PORTS=8000,8080,8081,8686,4317,4318,8889,13133
-if ! iptables -C DOCKER-USER -i eth0 -p tcp -m multiport \
-       --dports "$DROP_PORTS" -j DROP 2>/dev/null; then
-    iptables -I DOCKER-USER -i eth0 -p tcp -m multiport \
-      --dports "$DROP_PORTS" -j DROP
+# The rule list and the apply logic live in docker-firewall.sh, which is also
+# what trinity-docker-firewall.service runs on every subsequent boot — one
+# script, one DROP_PORTS list, two callers. Calling it here as well (rather than
+# relying on the unit alone) removes an ordering question: cloud-init's
+# per-instance scripts and the unit are both in multi-user.target, and the rules
+# must be in place before step 6 starts the containers. The script is idempotent.
+if ! /opt/trinity-firstboot/docker-firewall.sh; then
+    echo "WARNING: could not apply the DOCKER-USER DROP rules. Container ports" >&2
+    echo "         may be reachable from the internet." >&2
+    echo "         Re-run: /opt/trinity-firstboot/docker-firewall.sh" >&2
 fi
 
-# iptables-persistent is installed at BUILD time (01-provision.sh). Installing
-# it here was `>/dev/null 2>&1 || true` (#2281 review I1) — at the busiest apt
-# moment a droplet ever has, and a transient mirror failure then made the save
-# silently impossible: the boot still reported success and the DROP rules were
-# simply gone at the next reboot, the ports reopening with no symptom anywhere.
-# Only the save remains, and its failure is now loud.
-if ! netfilter-persistent save; then
-    echo "WARNING: netfilter-persistent save failed. The DOCKER-USER DROP rules" >&2
-    echo "         are active NOW but will not survive a reboot." >&2
-    echo "         Re-run: /opt/trinity-firstboot/firstboot.sh" >&2
-fi
+# Enabled at build time; re-asserted here so a droplet whose snapshot predates
+# that step still gets the rules back after a reboot.
+systemctl enable trinity-docker-firewall.service >/dev/null 2>&1 || true
 
 # --- 5. Caddy ----------------------------------------------------------------
 # Let's Encrypt issues certificates for bare IP addresses as of 2026-01-15, via

--- a/packer/digitalocean/scripts/01-provision.sh
+++ b/packer/digitalocean/scripts/01-provision.sh
@@ -37,20 +37,22 @@ apt-get update -q
 apt-get install -y -q docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 systemctl enable docker
 
-# --- iptables-persistent -----------------------------------------------------
-# Installed HERE rather than at first boot (#2281 review I1). First boot did it
-# as `>/dev/null 2>&1 || true` at the busiest apt moment a droplet ever has, so
-# a transient mirror failure left the DOCKER-USER DROP rules unsaved and gone at
-# the next reboot — silently. Baked once at build time it is deterministic for
-# every droplet from this snapshot, and first boot only has to run the save.
+# --- Docker firewall persistence (NOT iptables-persistent) -------------------
+# iptables-persistent cannot be installed here. `ufw` declares
+# `Breaks: iptables-persistent, netfilter-persistent` with no version, so apt
+# resolves `apt-get install iptables-persistent` by REMOVING ufw — silently, and
+# the build then died 90 lines later at `ufw --force reset` with
+# "ufw: command not found" (exit 127), after pulling all five images.
 #
-# The debconf answers must be preseeded: the package otherwise prompts to save
-# the CURRENT ruleset, and a prompt in a non-interactive Packer run hangs until
-# the provisioner times out. `false` on both — first boot saves the ruleset that
-# actually matters, after Docker and the DROP rules exist.
-echo iptables-persistent iptables-persistent/autosave_v4 boolean false | debconf-set-selections
-echo iptables-persistent iptables-persistent/autosave_v6 boolean false | debconf-set-selections
-apt-get install -y -q iptables-persistent
+# ufw is the one that has to stay: DigitalOcean's own 99-img-check.sh calls
+# `ufw status` unconditionally on Ubuntu and reports "No firewall is configured"
+# if it is missing, which is not something to hand a Marketplace reviewer.
+#
+# The DOCKER-USER rules are persisted instead by trinity-docker-firewall.service,
+# installed below. That is also the better mechanism on its own merits:
+# netfilter-persistent restores rules at boot with no ordering against
+# docker.service, and the DOCKER-USER chain does not exist until Docker creates
+# it — so the thing being replaced was itself racy.
 
 # --- Caddy (reverse proxy + automatic certificates) --------------------------
 # PINNED, and the floor is load-bearing rather than hygiene. The whole
@@ -158,6 +160,13 @@ install -D -m 0755 /tmp/trinity-files/var/lib/cloud/scripts/per-instance/001-tri
   /var/lib/cloud/scripts/per-instance/001-trinity
 install -D -m 0755 /tmp/trinity-files/etc/update-motd.d/99-trinity \
   /etc/update-motd.d/99-trinity
+install -D -m 0755 /tmp/trinity-files/opt/trinity-firstboot/docker-firewall.sh \
+  /opt/trinity-firstboot/docker-firewall.sh
+install -D -m 0644 /tmp/trinity-files/etc/systemd/system/trinity-docker-firewall.service \
+  /etc/systemd/system/trinity-docker-firewall.service
+# Enabled at BUILD time so the rules are reapplied on every boot of every droplet,
+# including reboots that never re-run first boot (cloud-init is per-instance).
+systemctl enable trinity-docker-firewall.service
 rm -rf /tmp/trinity-files
 
 # Ubuntu's stock MOTD is noisy and pushes ours off the first screen; the

--- a/packer/digitalocean/scripts/01-provision.sh
+++ b/packer/digitalocean/scripts/01-provision.sh
@@ -4,6 +4,19 @@
 # from it — so nothing droplet-specific and nothing secret may be produced here.
 set -euo pipefail
 
+# Packer's shell provisioner runs a non-login, non-interactive SSH shell, whose
+# PATH does not reliably carry the sbin directories. Every tool used up to the
+# firewall block lives in /usr/bin (apt-get, gpg, systemctl, git, docker), so the
+# first /usr/sbin binary reached is `ufw` — and the build died there with
+# "ufw: command not found" (exit 127) AFTER pulling all five images, five and a
+# half minutes in. Ubuntu 24.04 also merged /sbin into /usr/sbin, so both names
+# are listed for older bases.
+#
+# Set once at the top rather than absolute-pathing each call: the next sbin tool
+# added below would otherwise reintroduce the same failure, at the same late
+# point in the build.
+export PATH="/usr/local/sbin:/usr/sbin:/sbin:${PATH}"
+
 : "${TRINITY_IMAGE_TAG:?TRINITY_IMAGE_TAG must be passed by the Packer build}"
 
 echo "=== Trinity 1-Click build: baking ${TRINITY_IMAGE_TAG} ==="

--- a/packer/digitalocean/scripts/90-cleanup-and-check.sh
+++ b/packer/digitalocean/scripts/90-cleanup-and-check.sh
@@ -22,10 +22,27 @@ git -C /tmp/marketplace-partners remote add origin \
 git -C /tmp/marketplace-partners fetch -q --depth 1 origin "$MP_COMMIT"
 git -C /tmp/marketplace-partners checkout -q FETCH_HEAD
 
+# Stage the checker OUTSIDE /tmp before cleanup runs. DigitalOcean's own
+# 90-cleanup.sh does `rm -rf /tmp/* /var/tmp/*`, which deletes the checkout it
+# was just cloned into — so running img_check.sh from /tmp after cleanup is not
+# merely fragile, it is impossible:
+#
+#     bash: /tmp/marketplace-partners/scripts/99-img-check.sh: No such file or directory
+#
+# This is why img_check had never actually run: `packer build` had never run
+# either, and the two failures hid each other.
+#
+# /dev/shm rather than /opt or /root, for two reasons. It is tmpfs, so the staged
+# copy is not part of the snapshot's filesystem and nothing has to be deleted
+# afterwards — which keeps the rule above intact, that NOTHING runs after
+# img_check. And it survives cleanup, which only clears /tmp and /var/tmp.
+IMG_CHECK=/dev/shm/99-img-check.sh
+cp /tmp/marketplace-partners/scripts/99-img-check.sh "$IMG_CHECK"
+
 echo "=== cleanup.sh ==="
 bash /tmp/marketplace-partners/scripts/90-cleanup.sh
 
 echo "=== img_check.sh ==="
 # img_check exits non-zero on any finding, which fails the Packer build — the
 # snapshot is never created from a droplet that would be rejected at review.
-bash /tmp/marketplace-partners/scripts/99-img-check.sh
+bash "$IMG_CHECK"

--- a/packer/digitalocean/scripts/90-cleanup-and-check.sh
+++ b/packer/digitalocean/scripts/90-cleanup-and-check.sh
@@ -39,6 +39,24 @@ git -C /tmp/marketplace-partners checkout -q FETCH_HEAD
 IMG_CHECK=/dev/shm/99-img-check.sh
 cp /tmp/marketplace-partners/scripts/99-img-check.sh "$IMG_CHECK"
 
+# Purge DigitalOcean's own droplet-agent before their cleanup runs.
+#
+# The stock ubuntu-24-04-x64 base carries it (the build's apt sources show
+# repos-droplet.digitalocean.com/apt/droplet-agent), and img_check treats its
+# directory as a hard failure, not a warning:
+#
+#     [FAIL] DigitalOcean directory detected.
+#
+# Any FAIL makes img_check `exit 1`, which fails the build — so with this left in
+# place no snapshot can ever be produced. Their own 90-cleanup.sh does NOT remove
+# it; the remedy in img_check's own output is this purge. DigitalOcean installs
+# the agent per-droplet, so it must not be baked into a submitted image.
+echo "=== purging droplet-agent ==="
+DEBIAN_FRONTEND=noninteractive apt-get purge -y -q droplet-agent || true
+# The package purge leaves empty directories behind on some base images, and the
+# check tests for the directory, not the package.
+rm -rf /opt/digitalocean
+
 echo "=== cleanup.sh ==="
 bash /tmp/marketplace-partners/scripts/90-cleanup.sh
 

--- a/packer/digitalocean/trinity.pkr.hcl
+++ b/packer/digitalocean/trinity.pkr.hcl
@@ -75,6 +75,25 @@ source "digitalocean" "trinity" {
 build {
   sources = ["source.digitalocean.trinity"]
 
+  # FIRST, before anything touches apt. Ubuntu's cloud images run apt-daily and
+  # unattended-upgrades on boot, and they hold /var/lib/dpkg/lock-frontend while
+  # Packer's SSH session is already open — so 01-provision.sh's opening
+  # `apt-get update` races them and the build dies with
+  # "E: Could not get lock /var/lib/dpkg/lock-frontend" (apt exit 100).
+  # Intermittent, so it reads as a flake; it is not one, and a build that only
+  # succeeds sometimes is not something to hand a Marketplace reviewer.
+  #
+  # This is DigitalOcean's own prescribed remedy, not an invention: their
+  # reference template (marketplace-partners/marketplace-image.json, the same
+  # repo 90-cleanup-and-check.sh already pins) opens with exactly this
+  # provisioner. Ours had no wait of any kind.
+  #
+  # It belongs in the template rather than at the top of 01-provision.sh because
+  # the `file` provisioner below also runs before that script.
+  provisioner "shell" {
+    inline = ["cloud-init status --wait"]
+  }
+
   # Files first: the per-instance script and MOTD must exist before cleanup runs.
   provisioner "file" {
     source      = "files/"

--- a/packer/digitalocean/trinity.pkr.hcl
+++ b/packer/digitalocean/trinity.pkr.hcl
@@ -123,7 +123,18 @@ build {
   # It belongs in the template rather than at the top of 01-provision.sh because
   # the `file` provisioner below also runs before that script.
   provisioner "shell" {
-    inline = ["cloud-init status --wait"]
+    inline = [
+      "cloud-init status --wait",
+      # Create the file provisioner's destination BEFORE it runs. This is not
+      # tidiness — with the destination absent, Packer flattens the upload and
+      # strips the top-level directory names, so `files/opt/trinity-firstboot/
+      # firstboot.sh` lands at `/tmp/trinity-files/trinity-firstboot/
+      # firstboot.sh` and every `install /tmp/trinity-files/opt/...` below fails
+      # with "cannot stat". Verified both ways against a live droplet: absent,
+      # the tree comes up as trinity-firstboot/ update-motd.d/ systemd/ lib/;
+      # present, it comes up as opt/ etc/ var/ exactly as the bundle is laid out.
+      "mkdir -p /tmp/trinity-files",
+    ]
   }
 
   # Files first: the per-instance script and MOTD must exist before cleanup runs.

--- a/packer/digitalocean/trinity.pkr.hcl
+++ b/packer/digitalocean/trinity.pkr.hcl
@@ -46,6 +46,33 @@ variable "image_tag" {
   }
 }
 
+# Optional: build with an SSH key that ALREADY exists on the account, instead of
+# letting the builder import a temporary one per run.
+#
+# Left unset (the default) the builder imports a key and creates the droplet in
+# the next API call — and DigitalOcean does not reliably resolve the new key id
+# that fast. The first real build of this bundle lost that race on 4 of 5
+# creates, each failing in ~7 seconds with
+# "422 ... <id> are invalid key identifiers for Droplet creation", and each
+# leaking the temporary key (Packer's own cleanup then 404s on it).
+#
+# Supplying a pre-made key removes the window entirely, because nothing is
+# created during the build. Both must be given together; `ssh_key_id = 0` and an
+# empty path mean "unset", which is exactly the old behaviour.
+#
+#   doctl compute ssh-key import trinity-packer-build --public-key-file ~/.ssh/id_ed25519.pub
+variable "ssh_key_id" {
+  type        = number
+  default     = 0
+  description = "ID of an existing DigitalOcean SSH key. 0 = let Packer create a temporary one."
+}
+
+variable "ssh_private_key_file" {
+  type        = string
+  default     = ""
+  description = "Private key matching ssh_key_id. Required when ssh_key_id is set."
+}
+
 variable "region" {
   type    = string
   default = "nyc3"
@@ -70,6 +97,11 @@ source "digitalocean" "trinity" {
   size          = var.build_size
   ssh_username  = "root"
   snapshot_name = local.snapshot_name
+
+  # Both zero-valued unless the operator supplied them; the builder then falls
+  # back to importing a temporary key, which is the pre-existing behaviour.
+  ssh_key_id           = var.ssh_key_id
+  ssh_private_key_file = var.ssh_private_key_file
 }
 
 build {

--- a/tests/unit/test_2281_firstboot_password.py
+++ b/tests/unit/test_2281_firstboot_password.py
@@ -1,0 +1,87 @@
+"""Behavioural guard: first boot's password generator survives `set -o pipefail` (#2281).
+
+Bug: the generator was
+
+    ADMIN_PASSWORD="$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 24)"
+
+inside a script that opens with `set -euo pipefail`. `head` closes the pipe after
+24 bytes, `tr` dies of SIGPIPE against an endless source, `pipefail` surfaces that
+non-zero status out of the command substitution, and `set -e` ends the script.
+
+It killed first boot on the very first droplet ever created from the snapshot —
+three lines in, before anything but the header had been written to the log,
+leaving a box with no Trinity, no certificate and no admin password. It could
+never have worked on any droplet; nobody had run one.
+
+The guard EXECUTES the real block rather than pattern-matching it. A static rule
+would only know the one spelling that was wrong, and the failure mode is a
+runtime signal, not a syntax error — `bash -n` passes on the broken version.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_FIRSTBOOT = (
+    _ROOT / "packer" / "digitalocean" / "files" / "opt" / "trinity-firstboot" / "firstboot.sh"
+)
+
+_BLOCK_RE = re.compile(
+    r"# --- password-generation.*?\n(.*?)\s*# --- end password-generation ---",
+    re.DOTALL,
+)
+
+
+@pytest.fixture(scope="module")
+def generator_block() -> str:
+    m = _BLOCK_RE.search(_FIRSTBOOT.read_text())
+    assert m, (
+        "firstboot.sh no longer delimits its password generation with the "
+        "`# --- password-generation ---` markers this test executes."
+    )
+    return m.group(1)
+
+
+def test_generator_succeeds_under_pipefail(generator_block: str) -> None:
+    """The exact failure: a non-zero status escaping the command substitution."""
+    script = "set -euo pipefail\n" + generator_block + '\nprintf "%s" "$ADMIN_PASSWORD"\n'
+    r = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert r.returncode == 0, (
+        "first boot's password generation exits non-zero under `set -euo pipefail`, "
+        "which ends the script before Trinity is ever started. "
+        f"stderr: {r.stderr.strip()!r}"
+    )
+    assert len(r.stdout) == 24, f"expected a 24-character password, got {len(r.stdout)}"
+    assert r.stdout.isalnum(), f"password is not alphanumeric: {r.stdout!r}"
+
+
+def test_generator_does_not_pipe_an_endless_source_into_head(generator_block: str) -> None:
+    """Named separately so the reason survives a future rewrite.
+
+    Passing the behavioural test above is what matters, but a reader changing this
+    block should see the specific shape that must not come back.
+    """
+    # Strip comments first — the block deliberately quotes the broken form in
+    # prose so a future reader knows what must not come back.
+    code = "\n".join(
+        line for line in generator_block.splitlines() if not line.lstrip().startswith("#")
+    )
+    collapsed = " ".join(code.split())
+    assert not re.search(r"/dev/urandom\s*\|\s*head", collapsed), (
+        "piping /dev/urandom straight into `head` re-creates the SIGPIPE abort."
+    )
+    assert not re.search(r"tr\s+-dc[^|]*</dev/urandom\s*\|", collapsed), (
+        "`tr -dc ... </dev/urandom |` puts an endless producer upstream of a "
+        "reader that closes early — the original bug."
+    )
+
+
+def test_the_script_really_does_set_pipefail() -> None:
+    """Without this the guard above is vacuous."""
+    assert re.search(r"^set -euo pipefail$", _FIRSTBOOT.read_text(), re.MULTILINE), (
+        "firstboot.sh no longer sets `-euo pipefail`; this test's premise is gone."
+    )

--- a/tests/unit/test_2281_firstboot_port_exposure.py
+++ b/tests/unit/test_2281_firstboot_port_exposure.py
@@ -34,6 +34,14 @@ _HOSTED = _ROOT / "docker-compose.hosted.yml"
 _FIRSTBOOT = (
     _ROOT / "packer" / "digitalocean" / "files" / "opt" / "trinity-firstboot" / "firstboot.sh"
 )
+# The DROP list and the iptables calls moved out of firstboot.sh into a script
+# shared with trinity-docker-firewall.service, so the rules survive a reboot
+# without iptables-persistent (which apt cannot install beside ufw). FRONTEND_PORT
+# is still first boot's, so this test reads both files.
+_FIREWALL = (
+    _ROOT / "packer" / "digitalocean" / "files" / "opt" / "trinity-firstboot"
+    / "docker-firewall.sh"
+)
 
 # `DROP_PORTS=8000,8080,8081,...` — one variable feeds both the -C probe and the
 # -I insert, so there is exactly one list to read.
@@ -50,9 +58,14 @@ def firstboot() -> str:
 
 
 @pytest.fixture(scope="module")
-def drop_ports(firstboot: str) -> set[int]:
-    m = _DROP_RE.search(firstboot)
-    assert m, "firstboot.sh no longer declares a single DROP_PORTS list"
+def firewall() -> str:
+    return _FIREWALL.read_text()
+
+
+@pytest.fixture(scope="module")
+def drop_ports(firewall: str) -> set[int]:
+    m = _DROP_RE.search(firewall)
+    assert m, "docker-firewall.sh no longer declares a single DROP_PORTS list"
     return {int(p) for p in m.group(1).split(",")}
 
 
@@ -108,7 +121,7 @@ def test_every_published_port_is_dropped(drop_ports: set[int], frontend_port: in
         "docker-compose.hosted.yml publishes these host ports on 0.0.0.0 and the "
         "1-Click DOCKER-USER DROP list does not cover them, so they are reachable "
         f"from the internet on every droplet: {missing}. Add them to DROP_PORTS in "
-        "packer/digitalocean/files/opt/trinity-firstboot/firstboot.sh."
+        "packer/digitalocean/files/opt/trinity-firstboot/docker-firewall.sh."
     )
 
 
@@ -124,14 +137,73 @@ def test_frontend_port_is_dropped(drop_ports: set[int], frontend_port: int) -> N
     )
 
 
-def test_probe_and_insert_share_one_list(firstboot: str) -> None:
+def test_probe_and_insert_share_one_list(firewall: str) -> None:
     """A -C probe that differs from the -I insert never matches its own rule.
 
     It would then insert a duplicate DROP on every re-run of first boot, which is
     the documented recovery step for a failed boot.
     """
-    dports = re.findall(r'--dports\s+(\S+)', firstboot)
-    assert dports, "firstboot.sh no longer installs a multiport DROP rule"
+    dports = re.findall(r'--dports\s+(\S+)', firewall)
+    assert dports, "docker-firewall.sh no longer installs a multiport DROP rule"
     assert set(dports) == {'"$DROP_PORTS"'}, (
         f"the DROP rule's port list is spelled more than one way: {sorted(set(dports))}"
+    )
+
+
+def test_ufw_and_iptables_persistent_are_never_both_installed() -> None:
+    """`ufw` Breaks `iptables-persistent`, so apt silently removes one (#2281).
+
+    The build installed ufw, then installed iptables-persistent to make the
+    DOCKER-USER rules survive a reboot. `ufw`'s control file carries an
+    unversioned ``Breaks: iptables-persistent, netfilter-persistent``, so apt
+    resolved that by REMOVING ufw — reporting it plainly and continuing — and the
+    build died ~90 lines later at ``ufw --force reset`` with "command not found",
+    five and a half minutes in, after pulling all five images.
+
+    Both halves of that are worth guarding. Reintroducing the package would
+    uninstall the firewall DigitalOcean's own img_check.sh looks for, and the
+    error it eventually produces points at the wrong line entirely.
+    """
+    provision = (
+        _ROOT / "packer" / "digitalocean" / "scripts" / "01-provision.sh"
+    ).read_text()
+    live = [
+        line
+        for line in provision.splitlines()
+        if not line.lstrip().startswith("#")
+        and ("iptables-persistent" in line or "netfilter-persistent" in line)
+    ]
+    assert not live, (
+        "01-provision.sh references iptables-persistent/netfilter-persistent "
+        f"outside a comment: {live}. `ufw` Breaks both, so installing one removes "
+        "ufw. Reboot persistence is trinity-docker-firewall.service's job."
+    )
+    assert "ufw" in provision, "01-provision.sh no longer installs ufw"
+
+
+def test_firewall_rules_are_reapplied_on_every_boot() -> None:
+    """Without iptables-persistent, a unit is what survives a reboot.
+
+    cloud-init's per-instance hook runs once per droplet, so first boot alone
+    leaves the ports open again after the first reboot — the same silent
+    reopening #2281 review I1 already fixed once.
+    """
+    unit = (
+        _ROOT / "packer" / "digitalocean" / "files" / "etc" / "systemd" / "system"
+        / "trinity-docker-firewall.service"
+    )
+    assert unit.is_file(), "the boot-time firewall unit is missing"
+    text = unit.read_text()
+    assert "ExecStart=/opt/trinity-firstboot/docker-firewall.sh" in text
+    assert "After=docker.service" in text, (
+        "the unit must be ordered after docker.service — DOCKER-USER does not "
+        "exist until Docker creates it."
+    )
+    assert "WantedBy=multi-user.target" in text, "the unit is not enabled at boot"
+
+    provision = (
+        _ROOT / "packer" / "digitalocean" / "scripts" / "01-provision.sh"
+    ).read_text()
+    assert "systemctl enable trinity-docker-firewall.service" in provision, (
+        "the unit is shipped but never enabled, so it never runs."
     )

--- a/tests/unit/test_2281_packer_bundle_tracked.py
+++ b/tests/unit/test_2281_packer_bundle_tracked.py
@@ -37,12 +37,18 @@ _BUNDLE_ROOT = _REPO_ROOT / "packer" / "digitalocean" / "files"
 
 # `install -D -m 0755 /tmp/trinity-files/<src> \` — the packer `file` provisioner
 # uploads `files/` to `/tmp/trinity-files`, so <src> is a path inside the bundle.
-_INSTALL_RE = re.compile(r"/tmp/trinity-files/(\S+)")
+# The mode is captured rather than assumed: the bundle now installs a systemd
+# unit at 0644, and a unit file must NOT be executable.
+_INSTALL_RE = re.compile(r"install\s+-D\s+-m\s+(\d{4})\s+/tmp/trinity-files/(\S+)")
+
+
+def _bundle_installs() -> list[tuple[str, str]]:
+    text = _PROVISION.read_text()
+    return sorted({(m.group(2), m.group(1)) for m in _INSTALL_RE.finditer(text)})
 
 
 def _bundle_sources() -> list[str]:
-    text = _PROVISION.read_text()
-    return sorted({m.group(1) for m in _INSTALL_RE.finditer(text)})
+    return [src for src, _ in _bundle_installs()]
 
 
 def _tracked_bundle_files() -> dict[str, str]:
@@ -82,9 +88,17 @@ def test_every_installed_source_is_tracked():
     )
 
 
-@pytest.mark.parametrize("source", _bundle_sources())
-def test_installed_source_is_executable(source: str):
-    # Every current install site uses `-m 0755`; a 0644 source would still install
-    # 0755, but the intent should be visible in the tree the reviewer reads.
+@pytest.mark.parametrize("source,install_mode", _bundle_installs())
+def test_tracked_mode_matches_install_mode(source: str, install_mode: str):
+    """The tree a reviewer reads should say what the droplet gets.
+
+    `install -m` decides the mode on the droplet regardless, so this is about the
+    source being honest — a boot hook committed 0644 reads as inert, and a systemd
+    unit committed 0755 reads as a script someone can run.
+    """
+    expected = "100755" if install_mode == "0755" else "100644"
     mode = _tracked_bundle_files().get(source)
-    assert mode == "100755", f"{source} is tracked as {mode}, expected 100755"
+    assert mode == expected, (
+        f"{source} is installed -m {install_mode} but tracked as {mode}, "
+        f"expected {expected}"
+    )

--- a/tests/unit/test_2281_packer_cloud_init_wait.py
+++ b/tests/unit/test_2281_packer_cloud_init_wait.py
@@ -33,7 +33,9 @@ from pathlib import Path
 _ROOT = Path(__file__).resolve().parents[2]
 _TEMPLATE = _ROOT / "packer" / "digitalocean" / "trinity.pkr.hcl"
 
-_WAIT_RE = re.compile(r"""inline\s*=\s*\[\s*["']cloud-init status --wait["']\s*\]""")
+# Matches the command wherever it sits in an `inline` list — the list holds more
+# than one entry, so anchoring on a single-element block is too tight.
+_WAIT_RE = re.compile(r"""["']cloud-init status --wait["']""")
 _FILE_PROVISIONER_RE = re.compile(r'provisioner\s+"file"\s*\{')
 _PROVISION_SCRIPT_RE = re.compile(r'scripts/01-provision\.sh')
 
@@ -67,4 +69,37 @@ def test_wait_precedes_every_other_provisioner() -> None:
     assert wait.start() < script.start(), (
         "the cloud-init wait must come BEFORE 01-provision.sh, whose first action "
         "is `apt-get update`."
+    )
+
+
+_MKDIR_RE = re.compile(r'"mkdir -p /tmp/trinity-files"')
+
+
+def test_upload_destination_is_created_before_the_file_provisioner() -> None:
+    """Packer flattens the bundle when the destination does not exist (#2281).
+
+    The `file` provisioner uploads `files/` to `/tmp/trinity-files`, and
+    `01-provision.sh` then installs from `/tmp/trinity-files/opt/...`,
+    `/etc/...`, `/var/...`. With the destination absent, Packer strips the
+    top-level directory names and the tree arrives as `trinity-firstboot/`,
+    `update-motd.d/`, `systemd/`, `lib/` — so every install fails with
+    "cannot stat", five minutes into the build and after all five image pulls.
+
+    Verified both ways against a live droplet. With `mkdir -p` first, the tree
+    arrives as `opt/ etc/ var/` exactly as laid out.
+
+    Nothing else could have caught this: the bundle-tracked guard checks git, not
+    the upload, and `packer build` had never been run — the bundle shipped with
+    install paths that could not resolve on any droplet.
+    """
+    t = _text()
+    mkdir = _MKDIR_RE.search(t)
+    assert mkdir, (
+        "trinity.pkr.hcl no longer creates /tmp/trinity-files before uploading "
+        "into it — Packer will flatten the bundle and every install will fail."
+    )
+    first_file = _FILE_PROVISIONER_RE.search(t)
+    assert first_file, "trinity.pkr.hcl no longer has a file provisioner"
+    assert mkdir.start() < first_file.start(), (
+        "the mkdir must run BEFORE the file provisioner; afterwards it is useless."
     )

--- a/tests/unit/test_2281_packer_cloud_init_wait.py
+++ b/tests/unit/test_2281_packer_cloud_init_wait.py
@@ -103,3 +103,52 @@ def test_upload_destination_is_created_before_the_file_provisioner() -> None:
     assert mkdir.start() < first_file.start(), (
         "the mkdir must run BEFORE the file provisioner; afterwards it is useless."
     )
+
+
+def test_img_check_is_staged_outside_tmp() -> None:
+    """DO's own cleanup deletes the checker before it can run (#2281).
+
+    `90-cleanup-and-check.sh` clones DigitalOcean's tooling into
+    `/tmp/marketplace-partners`, runs their `90-cleanup.sh`, then runs their
+    `99-img-check.sh`. But `90-cleanup.sh` line 28 is::
+
+        rm -rf /tmp/* /var/tmp/*
+
+    so the checkout is gone by the time the checker is invoked::
+
+        bash: /tmp/marketplace-partners/scripts/99-img-check.sh: No such file or directory
+
+    The ordering is not fragile, it is impossible — which means DigitalOcean's
+    validation had never once run against this image. It went unnoticed because
+    `packer build` had never run either; the two failures hid each other, and the
+    check that would have caught the rest was the one being skipped.
+
+    The checker is staged in /dev/shm: tmpfs, so it survives the cleanup, is not
+    part of the snapshot, and needs no deletion afterwards — preserving the rule
+    that NOTHING runs after img_check.
+    """
+    script = (
+        _ROOT / "packer" / "digitalocean" / "scripts" / "90-cleanup-and-check.sh"
+    ).read_text()
+
+    invocations = re.findall(r"^\s*bash\s+(\S+)\s*$", script, re.MULTILINE)
+    assert invocations, "90-cleanup-and-check.sh no longer invokes anything with bash"
+
+    resolved = []
+    for raw in invocations:
+        if raw.startswith('"$') or raw.startswith("$"):
+            var = raw.strip('"').lstrip("$")
+            m = re.search(rf"^{re.escape(var)}=(\S+)\s*$", script, re.MULTILINE)
+            assert m, f"cannot resolve {raw} in 90-cleanup-and-check.sh"
+            resolved.append((raw, m.group(1)))
+        else:
+            resolved.append((raw, raw))
+
+    img_check = [(raw, path) for raw, path in resolved if "img-check" in path]
+    assert img_check, "90-cleanup-and-check.sh no longer runs img_check"
+    for raw, path in img_check:
+        assert not path.startswith("/tmp/"), (
+            f"img_check is invoked from {path} ({raw}), which DigitalOcean's own "
+            "90-cleanup.sh deletes with `rm -rf /tmp/*` immediately before. Stage "
+            "it outside /tmp."
+        )

--- a/tests/unit/test_2281_packer_cloud_init_wait.py
+++ b/tests/unit/test_2281_packer_cloud_init_wait.py
@@ -1,0 +1,70 @@
+"""Static guard: the 1-Click build waits for cloud-init before it touches apt (#2281).
+
+Bug: ``trinity.pkr.hcl`` carried no ``cloud-init status --wait`` provisioner, so
+``scripts/01-provision.sh`` opened with ``apt-get update`` while Ubuntu 24.04's
+boot-time ``apt-daily`` / ``unattended-upgrades`` units still held the dpkg lock.
+Packer's SSH is available well before those finish, so the build died with::
+
+    E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 1406
+    Script exited with non-zero exit status: 100
+
+Observed 2/2 on ``v0.9.5-rc2``, the first tag whose GHCR images made a build
+possible at all — so the whole bundle had shipped without one successful run.
+
+The remedy is DigitalOcean's own, not an invention: their reference template
+(``marketplace-partners/marketplace-image.json``, the same repo
+``90-cleanup-and-check.sh`` already pins by SHA) opens with exactly this
+provisioner.
+
+ORDER is the substance, which is why this asserts position and not presence. A
+wait that runs after the ``file`` provisioner or after ``01-provision.sh`` is
+inert, and the symptom of getting it wrong is a build that fails *intermittently*
+on someone else's machine and reads as a flake — so it gets retried rather than
+fixed, which is precisely what happened here before the cause was found.
+
+``packer build`` cannot be the guard: it needs a DO token and ~15 minutes, so it
+runs on nobody's PR. Repo-side, in the existing unit job, pure stdlib.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_TEMPLATE = _ROOT / "packer" / "digitalocean" / "trinity.pkr.hcl"
+
+_WAIT_RE = re.compile(r"""inline\s*=\s*\[\s*["']cloud-init status --wait["']\s*\]""")
+_FILE_PROVISIONER_RE = re.compile(r'provisioner\s+"file"\s*\{')
+_PROVISION_SCRIPT_RE = re.compile(r'scripts/01-provision\.sh')
+
+
+def _text() -> str:
+    return _TEMPLATE.read_text()
+
+
+def test_template_waits_for_cloud_init() -> None:
+    assert _WAIT_RE.search(_text()), (
+        "trinity.pkr.hcl no longer runs `cloud-init status --wait`. Without it the "
+        "first apt-get races Ubuntu's boot-time apt-daily/unattended-upgrades for "
+        "the dpkg lock and the build dies with apt exit 100."
+    )
+
+
+def test_wait_precedes_every_other_provisioner() -> None:
+    t = _text()
+    wait = _WAIT_RE.search(t)
+    assert wait, "no cloud-init wait to order (see test_template_waits_for_cloud_init)"
+
+    first_file = _FILE_PROVISIONER_RE.search(t)
+    assert first_file, "trinity.pkr.hcl no longer has a file provisioner"
+    assert wait.start() < first_file.start(), (
+        "the cloud-init wait must come BEFORE the file provisioner — a wait that "
+        "runs later cannot protect the apt calls that follow it."
+    )
+
+    script = _PROVISION_SCRIPT_RE.search(t)
+    assert script, "trinity.pkr.hcl no longer runs scripts/01-provision.sh"
+    assert wait.start() < script.start(), (
+        "the cloud-init wait must come BEFORE 01-provision.sh, whose first action "
+        "is `apt-get update`."
+    )

--- a/tests/unit/test_2281_packer_cloud_init_wait.py
+++ b/tests/unit/test_2281_packer_cloud_init_wait.py
@@ -152,3 +152,43 @@ def test_img_check_is_staged_outside_tmp() -> None:
             "90-cleanup.sh deletes with `rm -rf /tmp/*` immediately before. Stage "
             "it outside /tmp."
         )
+
+
+def test_droplet_agent_is_purged_before_img_check() -> None:
+    """`/opt/digitalocean` is a hard img_check FAIL, so the build cannot pass (#2281).
+
+    The stock `ubuntu-24-04-x64` base ships DigitalOcean's droplet-agent. Their
+    own `99-img-check.sh` treats its directory as a failure rather than a
+    warning::
+
+        [FAIL] DigitalOcean directory detected.
+
+    and any FAIL ends the script with `exit 1`, which fails the Packer build — so
+    while it is present, no snapshot can be produced at all. Their `90-cleanup.sh`
+    does not remove it; the remedy quoted in img_check's own output is a purge.
+    DigitalOcean installs the agent per droplet, so it must not be baked in.
+
+    This only became visible once img_check could run — see
+    test_img_check_is_staged_outside_tmp.
+    """
+    script = (
+        _ROOT / "packer" / "digitalocean" / "scripts" / "90-cleanup-and-check.sh"
+    ).read_text()
+
+    purge = re.search(r"apt-get purge[^\n]*droplet-agent", script)
+    assert purge, (
+        "the droplet-agent is never purged, so img_check will FAIL on "
+        "'DigitalOcean directory detected' and no snapshot will be created."
+    )
+    # The INVOCATION, not the first mention — "90-cleanup.sh" also appears in the
+    # file's header comment, well above the purge.
+    cleanup_call = re.search(r"^\s*bash\s+\S*90-cleanup\.sh\s*$", script, re.MULTILINE)
+    assert cleanup_call, "90-cleanup-and-check.sh no longer invokes DO's cleanup"
+    assert purge.start() < cleanup_call.start(), (
+        "the purge must run before DigitalOcean's cleanup, so the image handed to "
+        "img_check is already clean."
+    )
+    assert "rm -rf /opt/digitalocean" in script, (
+        "img_check tests for the DIRECTORY, not the package — a purge that leaves "
+        "empty directories behind still fails."
+    )


### PR DESCRIPTION
## What

The first-ever `packer build` of the 1-Click bundle. It could not produce a snapshot — eight defects, each of which stopped the build or the droplet. All eight are fixed here, and the result is a snapshot that boots to a working, HTTPS-served Trinity with no input.

The bundle shipped in #2281 with `packer build` explicitly deferred to "the first release with GHCR images". `v0.9.5-rc2` is that release. Everything below is what that first run found.

## Why nothing caught this

The defects concealed each other, and the one step that would have reported most of them never ran:

- `packer validate` does not read the payload tree.
- `bash -n` passes on every one of these — three are runtime signals, not syntax.
- The bundle-tracked guard checks that files exist **in git**, not that they arrive where the script reads them.
- DigitalOcean's own `img_check.sh` is deleted by their own `90-cleanup.sh` before it runs, so their validation had **never executed once**.

## The eight

| # | Defect | Effect |
|---|---|---|
| 1 | No `cloud-init status --wait` provisioner | First `apt-get` races boot-time `apt-daily` for the dpkg lock → exit 100. 2/2 builds. |
| 2 | sbin dirs absent from Packer's non-login PATH | Hardening only — see below. |
| 3 | `ufw` declares unversioned `Breaks: iptables-persistent` | Installing the latter **silently uninstalled ufw**; build died 90 lines later at `ufw --force reset`. Also leaves the image with no firewall for `img_check` to find. |
| 4 | Packer flattens the upload when the destination is absent | `files/opt/...` arrived as `trinity-firstboot/...`, so **every** `install` path was unreachable — including the cloud-init boot hook. |
| 5 | Their `90-cleanup.sh` does `rm -rf /tmp/*` | Deletes `img_check.sh` before it runs. Their validation had never executed. |
| 6 | `droplet-agent` never purged | `[FAIL] DigitalOcean directory detected` → `exit 1`. No snapshot can ever be produced. |
| 7 | `tr -dc … </dev/urandom \| head -c 24` under `set -o pipefail` | SIGPIPE → `set -e` → **first boot died three lines in**, on every droplet. |
| 8 | (2 above) | Kept as hardening, with the commit message corrected to say the observed symptom had a different cause. |

Two are worth reading in full: **#3**, where apt reported the removal as ordinary output and the error surfaced ninety lines away; and **#5**, which is why the checker that would have caught #3 and #6 was itself missing.

## Notable design change

`iptables-persistent` is replaced by `trinity-docker-firewall.service`, a oneshot ordered `After=docker.service`. This is not merely conflict avoidance — `netfilter-persistent` restores rules at boot with no ordering against Docker, and the `DOCKER-USER` chain does not exist until Docker creates it. The thing being replaced was itself racy. `DROP_PORTS` and the apply logic move into `docker-firewall.sh` so first boot and the unit share one list.

`ssh_key_id` / `ssh_private_key_file` are new optional vars. DO's API does not reliably resolve a just-imported key before the droplet create that references it — 4 of 5 creates failed with `422 … invalid key identifiers`. Supplying an existing key removes the window; both default to their zero values, so omitting them is exactly today's behaviour.

## Verification

Snapshot `trinity-v0-9-5-rc2-20260903` built, `img_check` reporting `0 Tests FAILED`. A droplet created from it:

- **~40s** to first boot settled, **~1m40s** to UI + healthy backend
- Real Let's Encrypt cert on the bare IP — `SAN: IP Address:…`, Sep 3 → Sep 10 (~6.7d, the `shortlived` profile), chain validates with **no `-k`**
- All eight Docker-published ports (8000/8080/8081/8686/4317/4318/8889/13133) **closed from off-box**; only 22/80/443 answer
- `cloud-init status: done`, no `firstboot-failed`
- `/api/version` → `0.9.5-rc2`, `git_commit bb31eef9…`, **`edition: "oss"`**, `enterprise_features: []`, `install_source: do-marketplace`
- Seeded fleet up; agent creation works

Not verified: a model round-trip. A 1-Click ships no model credential by design (`Authentication failure: Not logged in`), so this needs a key the operator supplies.

## Tests

Six guards added/updated, **each mutation-checked** (reverting the fix turns them red):

- cloud-init wait **and** upload-destination mkdir asserted by *position*, not presence — both are inert if they run late
- `ufw` + `iptables-persistent` can never both be installed
- a unit must reapply the DROP rules at boot (cloud-init's hook is per-instance; a reboot would otherwise reopen every port)
- `img_check` must not be invoked from `/tmp`
- `droplet-agent` purged before their cleanup
- password generation **executed** under `set -euo pipefail` rather than pattern-matched — a static rule would only know the one spelling that was wrong

The bundle-mode guard now derives the expected file mode from `install -m` instead of assuming 0755, since a systemd unit must not be executable.

Related to #2281. Unblocks the vendor application and bar 1 of the release floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxAk9CPZNh7hpNX3dyXJRh