### PR TITLE
fix(onboarding): one first-run card at a time, and the tunnel #2380 asked for

### DIFF
--- a/src/frontend/src/components/onboarding/ActivationChecklist.vue
+++ b/src/frontend/src/components/onboarding/ActivationChecklist.vue
@@ -15,7 +15,7 @@
   <div
     v-if="store.visible"
     data-testid="activation-checklist"
-    class="mx-4 mt-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm"
+    class="mx-4 mt-3 mb-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm"
   >
     <div class="flex items-start justify-between px-4 py-3">
       <div class="min-w-0">

--- a/src/frontend/src/components/onboarding/FinishSetupCard.vue
+++ b/src/frontend/src/components/onboarding/FinishSetupCard.vue
@@ -20,7 +20,7 @@
   preview loads on expand. Steady-state cost on a Dashboard load: zero.
 -->
 <template>
-  <div v-if="visible" data-testid="finish-setup-card" class="mx-4 mt-3">
+  <div v-if="visible" data-testid="finish-setup-card" class="mx-4 mt-3 mb-3">
     <BaseCard flush>
       <div class="flex items-center justify-between gap-3 px-4 pt-3 pb-1">
         <h3 class="text-sm font-[550] text-gray-900 dark:text-gray-100">Finish setup</h3>

--- a/src/frontend/src/components/onboarding/FrontDeskPanel.vue
+++ b/src/frontend/src/components/onboarding/FrontDeskPanel.vue
@@ -19,7 +19,7 @@
   <div
     v-if="store.visible"
     data-testid="front-desk"
-    class="mx-4 mt-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm"
+    class="mx-4 mt-3 mb-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm"
   >
     <div class="flex items-start justify-between px-4 pt-3">
       <div class="min-w-0">

--- a/src/frontend/src/components/onboarding/HardeningGuide.vue
+++ b/src/frontend/src/components/onboarding/HardeningGuide.vue
@@ -36,9 +36,9 @@
   neighbouring onboarding cards, which hand-roll their shell and are pre-ratchet.
 -->
 <template>
-  <div v-if="visible" data-testid="hardening-guide" class="mx-4 mt-3">
+  <div v-if="visible" data-testid="hardening-guide" class="mx-4 mt-3 mb-3">
     <BaseCard flush>
-      <div class="flex items-start justify-between gap-3 px-4 pt-3">
+      <div class="flex items-start justify-between gap-3 px-4 py-3">
         <div class="min-w-0">
           <div class="flex flex-wrap items-center gap-2">
             <h3 class="text-sm font-[550] text-gray-900 dark:text-gray-100">
@@ -51,9 +51,110 @@
           <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">
             {{ copy.headline }}
           </p>
-          <p class="mt-1 text-[12.5px] leading-[1.5] text-gray-500 dark:text-gray-400">
-            {{ copy.detail }}
-          </p>
+
+          <!--
+            ONE action on the card face. Adding a domain is the only step that is
+            collectable in-app, and it is also the completion condition that
+            retires this card — so it is the primary, and everything explanatory
+            moves behind the disclosure below. A first login should be able to
+            act on this in one glance without reading two columns of prose.
+          -->
+          <div class="mt-3">
+            <BaseButton
+              variant="primary"
+              size="sm"
+              data-testid="hardening-guide-settings"
+              @click="openSettings"
+            >
+              Add a domain
+            </BaseButton>
+          </div>
+
+          <!--
+            Native <details>: keyboard-accessible, no JS, no state to manage, and
+            not a primitive the catalog covers. The card is a nudge on a first
+            login — the reasoning has to be reachable, not unavoidable.
+          -->
+          <details class="mt-3" data-testid="hardening-guide-why">
+            <summary
+              class="cursor-pointer select-none text-[12.5px] text-action-primary-600 hover:text-action-primary-700 dark:text-action-primary-500 dark:hover:text-action-primary-400"
+            >
+              Why this matters
+            </summary>
+
+            <div class="mt-3 space-y-3 border-t border-gray-200 dark:border-gray-750 pt-3">
+              <p class="text-[12.5px] leading-[1.5] text-gray-500 dark:text-gray-400">
+                {{ copy.detail }}
+              </p>
+
+              <!--
+                Two paths, presented as COMPLEMENTARY (issue AC): one settles how
+                the instance is addressed, the other settles who can reach it at
+                all — and the second BUILDS ON the first, because a tunnel needs
+                the domain. The wording never offers them as an either/or.
+              -->
+              <div class="min-w-0">
+                <h4 class="text-sm font-[550] text-gray-900 dark:text-gray-100">
+                  Give it a real name
+                </h4>
+                <!--
+                  Trinity does not issue, renew, or install certificates: `public_chat_url`
+                  is a display/webhook-base setting and nothing in the tree reconfigures a
+                  proxy or a listener from it. So this promises only what setting it does —
+                  change the name Trinity hands out — and attributes the certificate change
+                  to whatever actually terminates TLS.
+                -->
+                <p class="mt-1 text-[12.5px] leading-[1.5] text-gray-500 dark:text-gray-400">
+                  Point a domain’s A record at this server, then set it as the
+                  <span class="text-gray-600 dark:text-gray-300">Public URL</span>
+                  in Settings → General so Trinity hands out the name instead of the IP. Trinity
+                  does not issue certificates itself — whatever terminates TLS in front of it
+                  picks up the name and can then use an ordinary long-lived certificate instead
+                  of a short-lived IP one.
+                </p>
+              </div>
+
+              <div class="min-w-0">
+                <h4 class="text-sm font-[550] text-gray-900 dark:text-gray-100">
+                  Serve it without exposing it
+                </h4>
+                <!--
+                  #2380, decision recorded 2026-09-01: a Cloudflare Tunnel, NOT a VPN.
+                  A VPN reaches the same posture but breaks every inbound integration —
+                  Telegram, WhatsApp, VoIP, public agent links, x402, inbound A2A and
+                  webhook triggers all call US. Slack survives on Socket Mode; nothing
+                  else does. VPN remains a documented deployment mode in
+                  docs/DEPLOYMENT.md; it is removed from this card only.
+
+                  The honest limitation is stated in the copy rather than hidden: the
+                  token has to reach `.env` and the tunnel starts under a compose
+                  profile, and Trinity runs in a container with no host privileges. So
+                  this path is guidance, and deliberately carries no button that could
+                  not finish the job.
+                -->
+                <p class="mt-1 text-[12.5px] leading-[1.5] text-gray-500 dark:text-gray-400">
+                  With that domain on Cloudflare, a tunnel lets this server stop listening on
+                  the public internet altogether:
+                  <span class="font-mono text-gray-600 dark:text-gray-300">cloudflared</span>
+                  connects outward to Cloudflare, and traffic arrives back through that
+                  connection. Inbound integrations — Telegram, WhatsApp, VoIP, public agent
+                  links, webhook triggers — keep working, because they still reach a public
+                  hostname. Trinity ships the service behind the
+                  <span class="font-mono text-gray-600 dark:text-gray-300">tunnel</span>
+                  compose profile, driven by
+                  <span class="font-mono text-gray-600 dark:text-gray-300">TUNNEL_TOKEN</span>
+                  in <span class="font-mono text-gray-600 dark:text-gray-300">.env</span>, so that
+                  last step happens on the host rather than from this page.
+                </p>
+              </div>
+
+              <p class="text-[12.5px] leading-[1.5] text-gray-500 dark:text-gray-400">
+                These two stack. A name settles how the instance is addressed; a tunnel
+                settles who can reach it at all. The tunnel needs the name, so it is the
+                second step rather than a different one.
+              </p>
+            </div>
+          </details>
         </div>
 
         <BaseButton
@@ -69,60 +170,6 @@
           </svg>
         </BaseButton>
       </div>
-
-      <!--
-        Two paths, presented as COMPLEMENTARY (issue AC): one settles how the
-        instance is addressed, the other settles who can reach it at all. The
-        wording below never offers them as an either/or.
-      -->
-      <div class="px-4 pt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <div class="min-w-0">
-          <h4 class="text-sm font-[550] text-gray-900 dark:text-gray-100">
-            Give it a real name
-          </h4>
-          <!--
-            Trinity does not issue, renew, or install certificates: `public_chat_url`
-            is a display/webhook-base setting and nothing in the tree reconfigures a
-            proxy or a listener from it. So this promises only what setting it does —
-            change the name Trinity hands out — and attributes the certificate change
-            to whatever actually terminates TLS.
-          -->
-          <p class="mt-1 text-[12.5px] leading-[1.5] text-gray-500 dark:text-gray-400">
-            Point a domain’s A record at this server, then set it as the
-            <span class="text-gray-600 dark:text-gray-300">Public URL</span>
-            in Settings → General so Trinity hands out the name instead of the IP. Trinity
-            does not issue certificates itself — whatever terminates TLS in front of it
-            picks up the name and can then use an ordinary long-lived certificate instead
-            of a short-lived IP one.
-          </p>
-          <div class="mt-2">
-            <BaseButton
-              variant="secondary"
-              size="sm"
-              data-testid="hardening-guide-settings"
-              @click="openSettings"
-            >
-              Open Settings → General
-            </BaseButton>
-          </div>
-        </div>
-
-        <div class="min-w-0">
-          <h4 class="text-sm font-[550] text-gray-900 dark:text-gray-100">
-            Decide who can reach it
-          </h4>
-          <p class="mt-1 text-[12.5px] leading-[1.5] text-gray-500 dark:text-gray-400">
-            Put the instance behind a VPN — Tailscale is what the managed fleet runs — and stop
-            serving the UI on the public internet. It stays reachable from the devices you
-            enrol, and from nowhere else.
-          </p>
-        </div>
-      </div>
-
-      <p class="px-4 py-3 text-[12.5px] leading-[1.5] text-gray-500 dark:text-gray-400">
-        These two stack. A name settles how the instance is addressed; a VPN settles who can
-        reach it at all. Most instances end up wanting both.
-      </p>
     </BaseCard>
   </div>
 </template>

--- a/src/frontend/src/views/Dashboard.vue
+++ b/src/frontend/src/views/Dashboard.vue
@@ -220,6 +220,15 @@
           </div>
         </div>
 
+        <!--
+          Onboarding stack (#2380). At most ONE card renders, ever — see the
+          `.onboarding-stack` rule below. Four independent surfaces landed here
+          from four issues, none aware of the others, and on a first login all
+          four can be true at once: ~520px of chrome above the product the
+          operator installed Trinity for, with four dismiss buttons. DOM order
+          IS priority order, highest first.
+        -->
+        <div class="onboarding-stack">
         <!-- Instance hardening guide (#2380). FIRST in the stack on purpose: a
              security-posture prompt outranks a getting-started nudge — a
              marketplace droplet is answering the public internet right now,
@@ -240,6 +249,7 @@
              One chassis rather than a fifth stacked nudge. Each section decides
              its own visibility; the card renders nothing when none applies. -->
         <FinishSetupCard />
+        </div>
 
     <!-- Timeline View (only visible in timeline mode) -->
     <template v-if="isTimelineMode">
@@ -1073,6 +1083,25 @@ function handleClickOutside(event) {
 </script>
 
 <style scoped>
+/*
+  One onboarding card at a time (#2380).
+
+  Every card in the stack is `v-if`'d, so a card that has nothing to say leaves
+  no element behind — which makes "the first ELEMENT child" exactly "the
+  highest-priority card that currently wants to speak". Hiding the rest in CSS
+  keeps each card's visibility predicate where it already lives (its own store,
+  its own localStorage dismissal) instead of lifting four of them into this
+  view, and dismissing the top card reveals the next one for free.
+
+  The wrapper carries no margin of its own on purpose: with every card hidden
+  it collapses to a zero-height empty div rather than a phantom gap. Each card
+  owns `mt-3 mb-3`, so whichever one shows is spaced on both sides — the pane
+  below is a full-bleed surface with no top padding of its own.
+*/
+.onboarding-stack > * ~ * {
+  display: none;
+}
+
 
 /*
  * Stats bar progressive degrade (#1830).

--- a/src/frontend/tests/unit/hardeningGuide.spec.js
+++ b/src/frontend/tests/unit/hardeningGuide.spec.js
@@ -61,6 +61,31 @@ const read = (rel) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)),
 const GUIDE_SFC = read('../../src/components/onboarding/HardeningGuide.vue')
 const SETTINGS_SFC = read('../../src/views/Settings.vue')
 
+/**
+ * The rendered copy, with the HTML comments removed.
+ *
+ * The comments here EXPLAIN decisions the copy must not state — the VPN the
+ * card no longer offers, the Tailscale install it must not appear over — so
+ * asserting "the card never says VPN" against the raw file would fail on the
+ * paragraph that records why. The assertion is about what a user reads.
+ *
+ * Stripped to a FIXPOINT rather than in one pass: a single
+ * `replace(/<!--[\s\S]*?-->/g, '')` leaves a live `<!--` behind on nested
+ * input (`<!--<!-- -->` -> `<!--`), which CodeQL flags as
+ * js/incomplete-multi-character-sanitization. Nothing untrusted reaches this —
+ * it reads a checked-in file — but the loop is both the rule's prescribed fix
+ * and the more correct strip, so there is no reason to carry the weaker one.
+ */
+const withoutComments = (source) => {
+  let out = source
+  let previous
+  do {
+    previous = out
+    out = out.replace(/<!--[\s\S]*?-->/g, '')
+  } while (out !== previous)
+  return out
+}
+
 /** A marketplace droplet still advertising HTTPS at its bare IP, seen by an admin. */
 const marketplaceIp = {
   featureFlagsLoaded: true,
@@ -310,11 +335,45 @@ describe('the two paths are complementary, not alternatives', () => {
     // the address and hardening the reach.
     expect(GUIDE_SFC).toContain('These two stack')
     expect(GUIDE_SFC).toMatch(/Give it a real name/)
-    expect(GUIDE_SFC).toMatch(/Decide who can reach it/)
-    expect(GUIDE_SFC).toMatch(/Tailscale/)
+    expect(GUIDE_SFC).toMatch(/Serve it without exposing it/)
     expect(GUIDE_SFC).toMatch(/A record/)
     // Deep-links at the field that actually writes `public_chat_url`.
     expect(GUIDE_SFC).toContain("/settings?tab=general")
+  })
+
+  it('offers a Cloudflare Tunnel, not a VPN (#2380, decided 2026-09-01)', () => {
+    // The second path was VPN/Tailscale until the issue recorded the swap: a
+    // VPN reaches the same posture but breaks every inbound integration, since
+    // Telegram, WhatsApp, VoIP, public links, x402, inbound A2A and webhook
+    // triggers all call us. PR #2431 shipped the pre-decision copy; this is the
+    // guard that stops it coming back.
+    const prose = withoutComments(GUIDE_SFC)
+    expect(prose).toMatch(/Cloudflare/)
+    expect(prose).toMatch(/cloudflared/)
+    expect(prose).toMatch(/TUNNEL_TOKEN/)
+    expect(prose).not.toMatch(/Tailscale/)
+    expect(prose.toLowerCase()).not.toMatch(/\bvpn\b/)
+  })
+
+  it('states the tunnel prerequisite and the step Trinity cannot take', () => {
+    const prose = withoutComments(GUIDE_SFC).replace(/\s+/g, ' ')
+    // Not an alternative to the domain — it NEEDS the domain (explicit AC).
+    expect(prose).toMatch(/With that domain on Cloudflare/)
+    expect(prose).toMatch(/The tunnel needs the name/)
+    // Honest about the half it cannot finish: the token reaches `.env` and the
+    // tunnel starts under a compose profile, from the host.
+    expect(prose).toMatch(/happens on the host rather than from this page/)
+  })
+
+  it('keeps one action on the card face and the reasoning behind a disclosure', () => {
+    // The card is a first-login nudge on a droplet that is answering the public
+    // internet; it must be actionable at a glance, not two columns of prose.
+    expect(GUIDE_SFC).toContain('<details')
+    expect(GUIDE_SFC).toContain('data-testid="hardening-guide-why"')
+    // Exactly one non-dismiss button, and it is the one collectable-in-app step.
+    expect(GUIDE_SFC).toMatch(/variant="primary"[\s\S]{0,200}Add a domain/)
+    const buttons = GUIDE_SFC.match(/<BaseButton/g) || []
+    expect(buttons.length, 'one action + one dismiss').toBe(2)
   })
 
   it('does not promise a certificate change Trinity does not perform', () => {
@@ -323,7 +382,7 @@ describe('the two paths are complementary, not alternatives', () => {
     // may promise the NAME changes, and must attribute the certificate to
     // whatever actually terminates TLS.
     // Template copy wraps across lines, so match on collapsed whitespace.
-    const prose = GUIDE_SFC.replace(/<!--[\s\S]*?-->/g, '').replace(/\s+/g, ' ')
+    const prose = withoutComments(GUIDE_SFC).replace(/\s+/g, ' ')
     expect(prose).not.toMatch(/90-day certificate then replaces/)
     expect(prose).not.toMatch(/certificate then replaces|replaces the short-lived/)
     expect(prose).toContain('Trinity does not issue certificates itself')
@@ -332,7 +391,7 @@ describe('the two paths are complementary, not alternatives', () => {
   })
 
   it('does not phrase them as an either/or', () => {
-    const prose = GUIDE_SFC.replace(/<!--[\s\S]*?-->/g, '') // comments explain, copy asserts
+    const prose = withoutComments(GUIDE_SFC) // comments explain, copy asserts
     expect(prose.toLowerCase()).not.toMatch(/\beither\b|\bor instead\b|\balternatively\b/)
   })
 

--- a/src/frontend/tests/unit/onboardingStack.spec.js
+++ b/src/frontend/tests/unit/onboardingStack.spec.js
@@ -1,0 +1,80 @@
+/**
+ * The Dashboard onboarding stack shows ONE card at a time (#2380).
+ *
+ * Four first-run surfaces landed on this view from four separate issues, none
+ * aware of the others: the hardening guide (#2380), the front desk (ent#319),
+ * the activation checklist (ent#238) and the sign-in email nudge (#2381). On a
+ * fresh marketplace install all four predicates can be true at once, which put
+ * ~520px of chrome and four dismiss buttons above the product.
+ *
+ * The gate is CSS rather than a lifted predicate on purpose. Every card is
+ * `v-if`'d, so "the first element child" already means "the highest-priority
+ * card that wants to speak" — and each card keeps its visibility where it
+ * lives today (its own store, its own localStorage dismissal), which a
+ * Dashboard-level chain would have had to duplicate and then keep in sync.
+ * Dismissing the top card reveals the next for free.
+ *
+ * Asserted on source text because `vitest.config.js` runs `environment: 'node'`
+ * with no component-mount harness (the ent#392 rule).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const read = (rel) =>
+  readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8')
+
+const DASHBOARD = read('../../src/views/Dashboard.vue')
+
+// DOM order IS priority order: security posture first, then the sign-in
+// identity prompt, then the two getting-started nudges. `FinishSetupCard`
+// (ent#437) carries the #2381 sign-in-email ask that AdminEmailNudge used to.
+const CARDS = [
+  ['HardeningGuide', '../../src/components/onboarding/HardeningGuide.vue'],
+  ['FrontDeskPanel', '../../src/components/onboarding/FrontDeskPanel.vue'],
+  ['ActivationChecklist', '../../src/components/onboarding/ActivationChecklist.vue'],
+  ['FinishSetupCard', '../../src/components/onboarding/FinishSetupCard.vue'],
+]
+
+describe('one onboarding card at a time', () => {
+  it('hides every sibling after the first inside the stack', () => {
+    // `> * ~ *` and not `:not(:first-child)`: both are correct here, but the
+    // sibling form states the intent — everything AFTER the first element.
+    expect(DASHBOARD).toMatch(/\.onboarding-stack > \* ~ \*\s*\{\s*display:\s*none;?\s*\}/)
+  })
+
+  it('wraps all four cards, and only them, in the stack', () => {
+    const stack = DASHBOARD.slice(
+      DASHBOARD.indexOf('<div class="onboarding-stack">'),
+      DASHBOARD.indexOf('</div>', DASHBOARD.indexOf('<FinishSetupCard />'))
+    )
+    expect(stack, 'stack wrapper must exist').toContain('onboarding-stack')
+    for (const [name] of CARDS) {
+      expect(stack, `${name} must be inside the stack`).toContain(`<${name}`)
+    }
+  })
+
+  it('keeps the cards in priority order, highest first', () => {
+    const positions = CARDS.map(([name]) => DASHBOARD.indexOf(`<${name}`))
+    expect(positions.every((p) => p > -1), 'every card is mounted').toBe(true)
+    expect([...positions].sort((a, b) => a - b)).toEqual(positions)
+  })
+})
+
+describe('the visible card is spaced on both sides', () => {
+  // The stack wrapper deliberately carries no margin: with every card hidden it
+  // must collapse to nothing rather than leave a phantom gap. So each card owns
+  // both margins — and the bottom one is load-bearing, because the pane below
+  // (timeline header, grid surface) is full-bleed with no top padding of its
+  // own, leaving the card's border touching it.
+  it.each(CARDS)('%s owns mt-3 and mb-3', (name, rel) => {
+    const root = read(rel).split('\n').find((l) => l.includes('mx-4'))
+    expect(root, `${name} root class`).toBeTruthy()
+    expect(root, `${name} needs a top gap`).toMatch(/\bmt-3\b/)
+    expect(root, `${name} needs a bottom gap`).toMatch(/\bmb-3\b/)
+  })
+
+  it('puts no margin on the wrapper itself', () => {
+    expect(DASHBOARD).toContain('<div class="onboarding-stack">')
+  })
+})


### PR DESCRIPTION
Closes the unmet **AC #4** on #2380. The provenance half of that issue shipped in #2431 (merged 2026-09-02); this is the copy and layout half it left behind. Deliberately **not** `Closes #2380` — that issue carries several ACs and this PR does not settle all of them.

## What this changes

**1. The second hardening path is a Cloudflare Tunnel, not a VPN.**
#2380 recorded that swap in a comment on 2026-09-01. #2431 merged a day later carrying the pre-decision VPN/Tailscale copy, so the AC was never met. The rationale is the issue's own: a VPN reaches the same posture but breaks every inbound integration — Telegram, WhatsApp, VoIP, public agent links, x402, inbound A2A and webhook triggers all call *us*, and only Slack survives on Socket Mode.

The copy states the prerequisite (the domain has to be on Cloudflare), says outright that the tunnel needs the name and is therefore the *second step* rather than a different one, and names the half Trinity cannot perform: `TUNNEL_TOKEN` reaches `.env` and the tunnel starts under a compose profile, from the host. It carries **no button** on purpose — Trinity runs in a container with no host privileges, so no button here could finish the job. VPN remains a documented deployment mode in `docs/DEPLOYMENT.md`; it is removed from this card only.

**2. The card face collapses to one action.**
Title, badge, one sentence, and `Add a domain` — the only step collectable in-app, and the completion condition that retires the card. Posture detail, both paths and the stacking sentence move behind a native `<details>`: keyboard-accessible, no JS, no state, and not a primitive the catalog covers.

**3. At most one onboarding card renders, ever.**
Four first-run surfaces landed on the Dashboard from four separate issues, none aware of the others: the hardening guide (#2380), the front desk (ent#319), the activation checklist (ent#238) and the finish-setup card (ent#437, which folds in #2381's sign-in-email ask). On a fresh marketplace install every predicate can be true at once — roughly 520px of chrome and four dismiss buttons above the product. ent#437 already collapsed what would have been a *fifth* card into an existing one; this caps what renders at **one**.

The gate is one CSS rule on a wrapper — `.onboarding-stack > * ~ * { display: none }` — rather than a `v-if` chain. Every card is already `v-if`'d, so "the first element child" means "the highest-priority card that currently wants to speak". A Vue-level chain would have to lift four visibility predicates into `Dashboard.vue` (they live in three Pinia stores plus component-local `localStorage` refs) and would break "dismiss the top card, the next appears", because the hardening card's in-session `dismissed` ref is not shared. DOM order **is** priority order.

**Spacing defect settled underneath.** Every card owned `mt-3` and nothing owned the gap below, so the last visible card's border sat flush against the pane — 0px in Timeline, worst in Grid where a white card meets a white full-bleed surface. Each card now owns `mt-3 mb-3`; the wrapper carries no margin of its own, so it collapses to a zero-height div when all four are silent.

## Verification

Automated: **84 files / 1835 tests** pass, `check:tokens` clean.

Driven in a real browser against a live stack with the four visibility predicates forced true:

- Exactly **one** card paints in Timeline, Grid and List, in both themes.
- Dismissing walks the whole stack in priority order — hardening guide → front desk → activation checklist → finish setup → nothing.
- **12px gap** under whichever card is showing, in all three modes; **no phantom gap** once all four are silent (`.onboarding-stack` measures 0px high).
- Collapsed face carries exactly two buttons (`Add a domain`, dismiss); the disclosure is closed on load, its summary takes focus and toggles on Enter.
- Rendered copy contains `cloudflared`, the `tunnel` compose profile, `TUNNEL_TOKEN` and the host-side step, and **zero** occurrences of Tailscale, VPN or WireGuard.
- Summary link resolves to `action-primary-600` in light and `-500` in dark.

## Note on overlap with #2516

While verifying, the hardening card would not render at all: both it and `AdminEmailNudge` read `authStore.userRole`, which the auth store has never defined (the getter is `role`). #2516 landed the same fix on `dev` about an hour before this rebase, with a stronger repo-wide `authRoleGetterContract.spec.js`, and replaced `AdminEmailNudge.vue` with `FinishSetupCard.vue`. My own fix commit was dropped as superseded; this branch is rebased onto that work and the stack now wraps `FinishSetupCard` as the fourth card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3FfTmxVyfmLNWtAXxMSQ1