### PR TITLE
ci(deps): stop Dependabot proposing runtime MAJOR bumps for base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -106,6 +106,19 @@ updates:
     labels:
       - dependencies
       - docker
+    # Runtime MAJORs are a coordinated migration, not a dependency bump (#2477).
+    # The Python version is a single declaration (#1891): the three image
+    # Dockerfiles are the source of truth and every `python-version:` in
+    # `.github/workflows/` must equal them, so a major cannot land as a
+    # Dockerfile-only edit. #2477 (3.13 -> 3.14) also could not build at all —
+    # `psycopg2-binary` ships no cp314 wheel, so pip fell back to a source build
+    # needing `pg_config`, which `-slim` does not carry. Ecosystem readiness is
+    # the thing to check first, and that is issue work, not PR review.
+    # Patch/minor still flow (that is where the CVE fixes are).
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
     groups:
       docker-base-images:
         patterns:


### PR DESCRIPTION
Follow-up to #2477 (closed unmerged); extends the #850 docker entry.

## Why

#2477 arrived as a routine `docker-base-images` group bump. It was actually **Python 3.13 → 3.14** across the backend, scheduler and agent base images simultaneously, and it could not build at all:

```
Getting requirements to build wheel: finished with status 'error'
Error: pg_config executable not found.
ERROR: Failed to build 'psycopg2-binary' when getting requirements to build wheel
```

`psycopg2-binary` publishes no cp314 wheel, so pip fell back to a source build needing `libpq-dev`, which `python:3.14-slim` does not carry. All six of that PR's failures cascade from that single step.

## Why ignore rather than review case-by-case

A runtime major is **not a dependency bump for this repo**, for two structural reasons:

1. **The Python version is a single declaration (#1891).** The three image Dockerfiles are the source of truth and every `python-version:` in `.github/workflows/` must equal them, enforced by `tests/unit/test_1891_python_version_parity.py`. A major therefore cannot correctly land as a Dockerfile-only edit — which is the only shape Dependabot can produce.
2. **The thing to evaluate first is ecosystem readiness**, not the diff. That is the stdlib-removal class `architecture.md` already records twice (`crypt` → #1615, `audioop` → the `audioop-lts` pin). It is issue work with a migration plan, not PR review.

So the auto-PR can never be the unit of work, and leaving it open just parks a permanently-red PR in the queue.

## Scope

Majors ignored for the **docker ecosystem only**. Patch and minor still flow — that is where the CVE fixes this entry exists for (#850) actually live, and nothing about that changes.

## Caveat worth knowing

`.github/dependabot.yml` is read from the **default branch (`main`)**, as the file's own header notes — so this takes effect after the next release cut. Until then Dependabot may reopen a major bump; close it and point here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)