### PR TITLE
feat(onboarding): the hardening card's second step — the Cloudflare Tunnel #2380 asked for

### DIFF
--- a/src/frontend/src/components/onboarding/FinishSetupCard.vue
+++ b/src/frontend/src/components/onboarding/FinishSetupCard.vue
@@ -20,7 +20,7 @@
   preview loads on expand. Steady-state cost on a Dashboard load: zero.
 -->
 <template>
-  <div v-if="visible" data-testid="finish-setup-card" class="mx-4 mt-3 mb-3">
+  <div ref="rootEl" v-if="visible" data-testid="finish-setup-card" class="mx-4 mt-3 mb-3">
     <BaseCard flush>
       <div class="flex items-center justify-between gap-3 px-4 pt-3 pb-1">
         <h3 class="text-sm font-[550] text-gray-900 dark:text-gray-100">Finish setup</h3>
@@ -152,7 +152,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '../../stores/auth'
 import { useSessionsStore } from '../../stores/sessions'
@@ -245,18 +245,59 @@ const prettyPreview = computed(() =>
 )
 
 // The admin status route is called only once the section is going to render —
-// never on a Dashboard load it will not act on. The warm variant marks itself
-// shown the moment it renders, so it is one-shot per browser, and stays on
-// screen for this visit (the ref is not flipped until the next load).
+// never on a Dashboard load it will not act on.
 watch(
   consentVisible,
   (now) => {
     if (!now) return
     store.load({ preview: false })
-    if (variant.value === 'warm') persistWarmShown()
   },
   { immediate: true }
 )
+
+/*
+ * The warm ask is spent only once it has actually been SEEN.
+ *
+ * `consentVisible` answers "does this section want to render", which is not the
+ * same question. The Dashboard shows one onboarding card at a time (#2380), and
+ * a card hidden by that rule still mounts — so marking the warm variant shown
+ * when the predicate flipped burned the one re-ask ent#437 exists for while it
+ * sat behind the hardening guide, and the operator later met the weaker cold
+ * copy, if they met one at all.
+ *
+ * IntersectionObserver is the right instrument rather than a `display` check:
+ * the card becomes visible when a SIBLING is dismissed, which changes no state
+ * this component can watch. `rootEl` only exists while `visible` is true, so
+ * the observer is attached and torn down as the card comes and goes.
+ */
+const rootEl = ref(null)
+let visibilityObserver = null
+
+function markWarmAskSeen(entries) {
+  if (!entries.some((e) => e.isIntersecting)) return
+  if (!consentVisible.value || variant.value !== 'warm') return
+  // The ref is deliberately NOT flipped: the ask stays on screen for this
+  // visit, and the next load reads the persisted value.
+  persistWarmShown()
+}
+
+onMounted(() => {
+  if (typeof IntersectionObserver !== 'function') return
+  visibilityObserver = new IntersectionObserver(markWarmAskSeen)
+  watch(
+    rootEl,
+    (el, prev) => {
+      if (prev) visibilityObserver.unobserve(prev)
+      if (el) visibilityObserver.observe(el)
+    },
+    { immediate: true }
+  )
+})
+
+onBeforeUnmount(() => {
+  if (visibilityObserver) visibilityObserver.disconnect()
+  visibilityObserver = null
+})
 
 function loadPreview() {
   store.load({ preview: true, force: true })

--- a/src/frontend/src/components/onboarding/HardeningGuide.vue
+++ b/src/frontend/src/components/onboarding/HardeningGuide.vue
@@ -59,7 +59,7 @@
             moves behind the disclosure below. A first login should be able to
             act on this in one glance without reading two columns of prose.
           -->
-          <div class="mt-3">
+          <div v-if="stage === 'address'" class="mt-3">
             <BaseButton
               variant="primary"
               size="sm"
@@ -93,7 +93,7 @@
                 all — and the second BUILDS ON the first, because a tunnel needs
                 the domain. The wording never offers them as an either/or.
               -->
-              <div class="min-w-0">
+              <div v-if="stage === 'address'" class="min-w-0">
                 <h4 class="text-sm font-[550] text-gray-900 dark:text-gray-100">
                   Give it a real name
                 </h4>
@@ -133,8 +133,8 @@
                   not finish the job.
                 -->
                 <p class="mt-1 text-[12.5px] leading-[1.5] text-gray-500 dark:text-gray-400">
-                  With that domain on Cloudflare, a tunnel lets this server stop listening on
-                  the public internet altogether:
+                  <template v-if="stage === 'address'">With that domain on Cloudflare, a</template><template v-else>With your domain on Cloudflare, a</template>
+                  tunnel lets this server stop listening on the public internet altogether:
                   <span class="font-mono text-gray-600 dark:text-gray-300">cloudflared</span>
                   connects outward to Cloudflare, and traffic arrives back through that
                   connection. Inbound integrations — Telegram, WhatsApp, VoIP, public agent
@@ -148,7 +148,10 @@
                 </p>
               </div>
 
-              <p class="text-[12.5px] leading-[1.5] text-gray-500 dark:text-gray-400">
+              <p
+                v-if="stage === 'address'"
+                class="text-[12.5px] leading-[1.5] text-gray-500 dark:text-gray-400"
+              >
                 These two stack. A name settles how the instance is addressed; a tunnel
                 settles who can reach it at all. The tunnel needs the name, so it is the
                 second step rather than a different one.
@@ -183,6 +186,7 @@ import BaseCard from '../base/BaseCard.vue'
 import BaseBadge from '../base/BaseBadge.vue'
 import BaseButton from '../base/BaseButton.vue'
 import {
+  hardeningStage,
   isHardeningGuideVisible,
   persistHardeningGuideDismissed,
   postureCopy,
@@ -193,9 +197,17 @@ const store = useSessionsStore()
 const authStore = useAuthStore()
 const router = useRouter()
 
+// Which of the two steps the card is on. `https-domain` means step one landed,
+// so the card advances rather than retiring — see `hardeningGuide.js`.
+const stage = computed(() => hardeningStage(store.installTlsPosture))
+
 // Read once at setup, so a dismissal made in another tab this session does not
-// pop the card back mid-render.
-const dismissed = ref(readHardeningGuideDismissed())
+// pop the card back mid-render. Kept PER STAGE: waving away "you are on a bare
+// IP" must not also consume tunnel advice the operator has never been shown.
+const dismissed = ref({
+  address: readHardeningGuideDismissed('address'),
+  tunnel: readHardeningGuideDismissed('tunnel'),
+})
 
 const copy = computed(() => postureCopy(store.installTlsPosture) || {})
 
@@ -211,7 +223,7 @@ const visible = computed(
       isAdmin: authStore.profileVerified && authStore.role === 'admin',
       marketplaceInstall: store.marketplaceInstall,
       installTlsPosture: store.installTlsPosture,
-      dismissed: dismissed.value,
+      dismissed: dismissed.value[stage.value],
     }) &&
     // A posture with no copy is one this card has nothing honest to say about.
     // Belt on the predicate, which already excludes the only such value today.
@@ -221,8 +233,9 @@ const visible = computed(
 const dismiss = () => {
   // Hidden for this session regardless of whether storage accepted the write —
   // the helper warns, and a refused write is not a failed verb to the user.
-  dismissed.value = true
-  persistHardeningGuideDismissed()
+  // Scoped to the stage on screen, so the other step can still have its turn.
+  dismissed.value = { ...dismissed.value, [stage.value]: true }
+  persistHardeningGuideDismissed(stage.value)
 }
 
 const openSettings = () => router.push('/settings?tab=general')

--- a/src/frontend/src/components/onboarding/hardeningGuide.js
+++ b/src/frontend/src/components/onboarding/hardeningGuide.js
@@ -14,11 +14,34 @@
 // configured, so a per-user table would be more machinery than the behaviour is
 // worth — and it must not add an endpoint to a first-boot security surface.
 export const HARDENING_GUIDE_DISMISSED_KEY = 'trinity_hardening_guide_dismissed'
+export const HARDENING_GUIDE_TUNNEL_DISMISSED_KEY = 'trinity_hardening_guide_tunnel_dismissed'
 
-// The posture that means the job is done. Kept as a named constant because two
-// places read it: the visibility predicate, and the copy table's deliberate
-// omission of an entry for it.
-export const SETTLED_POSTURE = 'https-domain'
+// The posture that completes step ONE. It does NOT retire the card: the guide
+// advises two steps, and retiring on the first meant the second was mentioned
+// once and then never again, on the one surface that raises it. At this posture
+// the card ADVANCES to the tunnel step instead, and a dismissal is what ends it.
+export const DOMAIN_POSTURE = 'https-domain'
+
+// Two stages, in the order the card advises them. `address` decides how the
+// instance is reached; `tunnel` decides who can reach it at all.
+export const HARDENING_STAGES = ['address', 'tunnel']
+
+/** Which step this posture puts the card on. */
+export function hardeningStage(installTlsPosture) {
+  return installTlsPosture === DOMAIN_POSTURE ? 'tunnel' : 'address'
+}
+
+/**
+ * Dismissal is PER STAGE, and that is load-bearing rather than tidy.
+ *
+ * One key would let a dismissal of "you are on a bare IP" silently consume the
+ * tunnel advice the operator has not been shown yet — the same shape as the
+ * ent#437 warm ask being spent behind another card. The address stage keeps the
+ * original key, so an existing dismissal keeps holding and nothing migrates.
+ */
+export function dismissKeyForStage(stage) {
+  return stage === 'tunnel' ? HARDENING_GUIDE_TUNNEL_DISMISSED_KEY : HARDENING_GUIDE_DISMISSED_KEY
+}
 
 /**
  * Should the guide render?
@@ -45,9 +68,10 @@ export const SETTLED_POSTURE = 'https-domain'
  * flag document it derives from is served to any authenticated principal. It
  * defaults FALSE so the safe direction — hidden — is what an omitted term buys.
  *
- * `https-domain` hides the card permanently with no client state at all: a
- * configured domain IS the completion condition, so the guide is self-retiring
- * and cannot linger on an instance that already did the work.
+ * `https-domain` no longer hides the card. It advances it: step one is done, so
+ * the card switches to the tunnel step and the operator gets one look at the
+ * advice before dismissing it. `dismissed` is therefore the only thing that
+ * ends the guide, and it is resolved per stage by the caller.
  */
 export function isHardeningGuideVisible({
   featureFlagsLoaded = false,
@@ -59,8 +83,10 @@ export function isHardeningGuideVisible({
   if (!featureFlagsLoaded) return false
   if (!isAdmin) return false
   if (!marketplaceInstall) return false
-  if (installTlsPosture === SETTLED_POSTURE) return false
   if (dismissed) return false
+  // `installTlsPosture` no longer gates visibility — it selects the STAGE (and
+  // therefore which copy speaks). An unknown posture has no copy, and the
+  // component's own belt hides the card rather than rendering an empty shell.
   return true
 }
 
@@ -115,6 +141,14 @@ export const POSTURE_COPY = {
     detail:
       'Trinity cannot inspect the certificate from here — it only knows the address it was told to advertise. If a marketplace image set this up, expect a short-lived certificate tied to the IP and renewed every few days. Either way, an IP address is awkward to share and answers to the whole public internet, so a real name is worth adding.',
   },
+  'https-domain': {
+    badge: 'Domain set',
+    badgeVariant: 'success',
+    headline:
+      'Your domain is set. One optional step is left \u2014 a Cloudflare Tunnel can take this server off the public internet.',
+    detail:
+      'Step one is done: Trinity now hands out a name rather than an IP, and whatever terminates TLS in front of it can pick up that name. The step below is about reach rather than address \u2014 unless something in front of this server already restricts it, it still answers anyone who finds the address. This one is optional, and dismissing it here is a fine answer.',
+  },
 }
 
 /** Copy for a posture, or `null` when the guide should not be speaking at all. */
@@ -122,10 +156,10 @@ export function postureCopy(posture) {
   return POSTURE_COPY[posture] || null
 }
 
-/** Read the persisted dismissal. Any storage failure reads as "not dismissed". */
-export function readHardeningGuideDismissed() {
+/** Read the persisted dismissal for one stage. Any storage failure reads as "not dismissed". */
+export function readHardeningGuideDismissed(stage = 'address') {
   try {
-    return localStorage.getItem(HARDENING_GUIDE_DISMISSED_KEY) === '1'
+    return localStorage.getItem(dismissKeyForStage(stage)) === '1'
   } catch {
     // Private mode / disabled storage. Showing the card again is the safe
     // direction for a security nudge; it is one click to wave away.
@@ -137,9 +171,9 @@ export function readHardeningGuideDismissed() {
  * Persist the dismissal. Returns whether it stuck — the caller hides the card
  * for this session either way, so a refusal is a warning, never a failed verb.
  */
-export function persistHardeningGuideDismissed() {
+export function persistHardeningGuideDismissed(stage = 'address') {
   try {
-    localStorage.setItem(HARDENING_GUIDE_DISMISSED_KEY, '1')
+    localStorage.setItem(dismissKeyForStage(stage), '1')
     return true
   } catch (e) {
     console.warn('[hardeningGuide] could not persist dismissal:', e?.message || e)

--- a/src/frontend/src/components/onboarding/hardeningGuide.js
+++ b/src/frontend/src/components/onboarding/hardeningGuide.js
@@ -117,7 +117,8 @@ export function isHardeningGuideVisible({
  * absence of information, `warning` for the posture whose advertised address
  * carries no encryption, `info` for one with room to improve.
  *
- * There is deliberately no `https-domain` entry — that posture never renders.
+ * `https-domain` is the one posture that speaks only to step two: step one is
+ * already done, so its copy opens on what is left rather than on an exposure.
  */
 export const POSTURE_COPY = {
   unconfigured: {

--- a/src/frontend/tests/unit/hardeningGuide.spec.js
+++ b/src/frontend/tests/unit/hardeningGuide.spec.js
@@ -49,8 +49,11 @@ import { useSessionsStore } from '@/stores/sessions'
 import { resetInFlight } from '@/utils/inflight'
 import {
   HARDENING_GUIDE_DISMISSED_KEY,
+  DOMAIN_POSTURE,
+  HARDENING_GUIDE_TUNNEL_DISMISSED_KEY,
   POSTURE_COPY,
-  SETTLED_POSTURE,
+  dismissKeyForStage,
+  hardeningStage,
   isHardeningGuideVisible,
   persistHardeningGuideDismissed,
   postureCopy,
@@ -159,20 +162,54 @@ describe('visibility', () => {
     expect(isHardeningGuideVisible({ ...marketplaceIp, isAdmin: true })).toBe(true)
   })
 
-  it('predicate: a configured domain hides it, with no client state involved', () => {
-    // Scope note: this exercises the PREDICATE against a hand-supplied posture.
-    // It says nothing about whether the store's posture actually changes without
-    // a reload — that path is `savePublicUrl` -> `loadFeatureFlags(true)` in
-    // `Settings.vue`, asserted separately below, and it is the half that was
-    // missing while this test passed.
-    expect(isHardeningGuideVisible({ ...marketplaceIp, installTlsPosture: SETTLED_POSTURE })).toBe(false)
-    expect(SETTLED_POSTURE).toBe('https-domain')
+  it('predicate: a configured domain ADVANCES the card, it does not retire it', () => {
+    // The guide advises two steps. Retiring on step one meant step two was
+    // mentioned once and then never again, on the only surface that raises it —
+    // so `https-domain` now selects the tunnel stage instead of hiding.
+    expect(DOMAIN_POSTURE).toBe('https-domain')
+    expect(isHardeningGuideVisible({ ...marketplaceIp, installTlsPosture: DOMAIN_POSTURE })).toBe(true)
+    expect(hardeningStage(DOMAIN_POSTURE)).toBe('tunnel')
+    // Everything short of a domain is still step one.
+    for (const posture of ['unconfigured', 'http', 'https-ip']) {
+      expect(hardeningStage(posture)).toBe('address')
+    }
+    // A dismissal is now the only thing that ends the guide.
+    expect(
+      isHardeningGuideVisible({ ...marketplaceIp, installTlsPosture: DOMAIN_POSTURE, dismissed: true })
+    ).toBe(false)
   })
 
-  it('is retired in-session by the save that configures the domain', () => {
+  it('scopes dismissal per stage, so step one cannot silently spend step two', () => {
+    // One key would let "you are on a bare IP, go away" also consume tunnel
+    // advice the operator has never been shown — the same shape as the ent#437
+    // warm ask being spent behind another card.
+    expect(dismissKeyForStage('address')).toBe(HARDENING_GUIDE_DISMISSED_KEY)
+    expect(dismissKeyForStage('tunnel')).toBe(HARDENING_GUIDE_TUNNEL_DISMISSED_KEY)
+    expect(dismissKeyForStage('address')).not.toBe(dismissKeyForStage('tunnel'))
+
+    // Dismissing the address stage leaves the tunnel stage unread.
+    persistHardeningGuideDismissed('address')
+    expect(readHardeningGuideDismissed('address')).toBe(true)
+    expect(readHardeningGuideDismissed('tunnel')).toBe(false)
+
+    // The address key keeps its original name, so an existing dismissal holds
+    // with nothing to migrate.
+    expect(HARDENING_GUIDE_DISMISSED_KEY).toBe('trinity_hardening_guide_dismissed')
+  })
+
+  it('the component resolves dismissal against the stage on screen', () => {
+    expect(GUIDE_SFC).toMatch(/hardeningStage\(store\.installTlsPosture\)/)
+    expect(GUIDE_SFC).toContain('dismissed: dismissed.value[stage.value]')
+    expect(GUIDE_SFC).toContain("persistHardeningGuideDismissed(stage.value)")
+    // Step one's action cannot render once the domain exists — there is nothing
+    // left to collect in-app, and a button that leads nowhere is the defect.
+    expect(GUIDE_SFC).toMatch(/v-if="stage === 'address'"[\s\S]{0,400}Add a domain/)
+  })
+
+  it('advances in-session on the save that configures the domain', () => {
     // `loadFeatureFlags` early-returns once `featureFlagsLoaded` is true, so
     // without the forced re-read an admin who follows this card's own
-    // instruction still sees it until a hard reload.
+    // instruction never sees the card ADVANCE to step two until a hard reload.
     const save = SETTINGS_SFC.slice(SETTINGS_SFC.indexOf('async function savePublicUrl()'))
     const body = save.slice(0, save.indexOf('\n}\n'))
     expect(body).toContain('sessionsStore.loadFeatureFlags(true)')
@@ -233,11 +270,29 @@ describe('dismissal', () => {
 describe('honest copy', () => {
   const ALL = Object.entries(POSTURE_COPY)
 
-  it('speaks for exactly the three postures that render', () => {
-    expect(Object.keys(POSTURE_COPY).sort()).toEqual(['http', 'https-ip', 'unconfigured'])
-    // The settled posture never renders, so it must have nothing to say.
-    expect(postureCopy(SETTLED_POSTURE)).toBeNull()
+  it('speaks for every posture that renders, and only those', () => {
+    expect(Object.keys(POSTURE_COPY).sort()).toEqual([
+      'http',
+      'https-domain',
+      'https-ip',
+      'unconfigured',
+    ])
+    // An unrecognised posture still has nothing to say, and the component's own
+    // belt hides the card rather than rendering an empty shell.
     expect(postureCopy('something-new')).toBeNull()
+  })
+
+  it('the tunnel stage names the remaining step on the card FACE', () => {
+    // At this stage there is no button — the last move happens on the host — so
+    // a reader who dismisses without expanding must still have met the point.
+    const { headline, detail, badgeVariant } = POSTURE_COPY['https-domain']
+    expect(headline).toMatch(/Cloudflare Tunnel/)
+    expect(headline.toLowerCase()).toMatch(/optional/)
+    expect(badgeVariant).toBe('success')
+    // Honest about reach: it hedges rather than asserting what is in front of
+    // this server, exactly as the `http` copy does.
+    expect(detail.toLowerCase()).toMatch(/unless something in front of/)
+    expect(detail.toLowerCase()).toMatch(/dismissing it here is a fine answer/)
   })
 
   // `install_tls_posture` is derived by PURE STRING PARSING of the URL this
@@ -321,11 +376,19 @@ describe('honest copy', () => {
   })
 
   it('never dresses any posture as a failure', () => {
+    // `success` earns its place on `https-domain` only: step one is genuinely
+    // done there, and the badge reports a completed step rather than a verdict
+    // on the connection. Nothing here may read as broken.
     for (const [posture, copy] of ALL) {
-      expect(['neutral', 'info', 'warning'], `${posture} badge`).toContain(copy.badgeVariant)
+      expect(['neutral', 'info', 'warning', 'success'], `${posture} badge`).toContain(
+        copy.badgeVariant
+      )
       expect(copy.badgeVariant, `${posture} must not read as broken`).not.toBe('danger')
       expect(copy.badgeVariant, `${posture} must not read as broken`).not.toBe('urgent')
     }
+    // And `success` is reserved for the one posture that completed a step.
+    const successes = ALL.filter(([, c]) => c.badgeVariant === 'success').map(([k]) => k)
+    expect(successes).toEqual(['https-domain'])
   })
 })
 
@@ -334,6 +397,9 @@ describe('the two paths are complementary, not alternatives', () => {
     // An explicit AC: the card must never read as a choice between hardening
     // the address and hardening the reach.
     expect(GUIDE_SFC).toContain('These two stack')
+    // Both live in the source; each is `v-if`'d to the stage it belongs to, so
+    // step one's block and the stacking sentence retire once the domain exists.
+    expect(GUIDE_SFC).toMatch(/v-if="stage === 'address'"[\s\S]{0,120}Give it a real name/)
     expect(GUIDE_SFC).toMatch(/Give it a real name/)
     expect(GUIDE_SFC).toMatch(/Serve it without exposing it/)
     expect(GUIDE_SFC).toMatch(/A record/)

--- a/src/frontend/tests/unit/onboardingStack.spec.js
+++ b/src/frontend/tests/unit/onboardingStack.spec.js
@@ -77,4 +77,39 @@ describe('the visible card is spaced on both sides', () => {
   it('puts no margin on the wrapper itself', () => {
     expect(DASHBOARD).toContain('<div class="onboarding-stack">')
   })
+
+  /*
+   * The one-card rule hides with CSS, so every hidden card still MOUNTS. Any
+   * "shown once" bookkeeping a card does off a Vue predicate is therefore spent
+   * behind whichever card is holding the slot.
+   *
+   * ent#437's warm re-ask is the live case: one shot per browser, and it exists
+   * precisely because a cold ask at first login converts badly. Marking it on
+   * `consentVisible` burned it while the hardening guide sat on top, and the
+   * operator met the weaker cold copy later — if they met one at all.
+   */
+  it('marks the warm ask shown only once it has really been seen', () => {
+    const sfc = read('../../src/components/onboarding/FinishSetupCard.vue')
+
+    // Real visibility, not the render predicate. A sibling being dismissed
+    // changes no state this component can watch, so an observer is the only
+    // instrument that sees the card arrive.
+    expect(sfc).toContain('IntersectionObserver')
+    expect(sfc).toMatch(/isIntersecting/)
+    expect(sfc).toContain('persistWarmShown()')
+
+    // The regression itself: persisting from inside the consentVisible watcher.
+    const watcher = sfc.slice(sfc.indexOf('watch(\n  consentVisible'))
+    const body = watcher.slice(0, watcher.indexOf('{ immediate: true }'))
+    expect(body, 'the visibility watcher must not spend the warm ask').not.toContain(
+      'persistWarmShown'
+    )
+
+    // Intersecting is necessary, not sufficient — the observer re-checks that
+    // the section still wants to render and is still the warm variant.
+    const marker = sfc.slice(sfc.indexOf('function markWarmAskSeen'))
+    const markerBody = marker.slice(0, marker.indexOf('\n}'))
+    expect(markerBody).toContain('consentVisible.value')
+    expect(markerBody).toContain("variant.value !== 'warm'")
+  })
 })


### PR DESCRIPTION
## What

#2531 landed the card-stack fix and the address stage. This carries the part of #2380 that was still missing: the hardening card does not retire itself the moment a domain is set — it advances to a **tunnel stage**.

Two commits:

- `f018463` — the two-stage card. `hardeningStage()` maps posture → stage, `dismissKeyForStage()` gives each stage its own localStorage key, and `https-domain` gains a `POSTURE_COPY` entry (badge `Domain set`, no primary button, Cloudflare named on the card face). `FinishSetupCard` gets an IntersectionObserver so the ent#437 warm telemetry ask is only marked shown when the card is really on screen, not while it sits hidden behind another card in the stack.
- `28294b0` — comment-only. The `POSTURE_COPY` docblock still ended with *"There is deliberately no `https-domain` entry — that posture never renders"*, directly above the `https-domain` entry the first commit added.

## Why the two stages don't share a dismissal

`trinity_hardening_guide_dismissed` and `trinity_hardening_guide_tunnel_dismissed` are separate keys on purpose. Dismissing the address stage is "I know about domains"; it must not silently consume an answer to a question the operator has not been shown yet.

## Verification

- `npx vitest run tests/unit/hardeningGuide.spec.js tests/unit/onboardingStack.spec.js` → 2 files, 46 tests, all pass
- Walked on a real DigitalOcean droplet built from this branch (fra1, source build, Let's Encrypt IP certificate, `TRINITY_INSTALL_SOURCE=do-marketplace`). `GET /api/settings/feature-flags` reported `install_source: "do-marketplace"`, `marketplace_install: true`, `install_tls_posture: "https-ip"` — the derivation the card depends on, confirmed against a real marketplace-shaped install rather than forced flags.

Not `Closes #2380` — that issue's other acceptance criteria are still unsettled, same call as #2531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2q1Xs3GtLLQemND1PgD99