### PR TITLE
fix(workspace): Escape yields to an overlay that already claimed it, mid-call (#2598)

### DIFF
--- a/docs/memory/feature-flows/chat-turn-cancellation.md
+++ b/docs/memory/feature-flows/chat-turn-cancellation.md
@@ -253,6 +253,31 @@ in `dev` — naming its ref here once threw a `ReferenceError` on every Escape
 keydown and made the whole feature dead on that surface, so `turnCancel.spec.js`
 pins the identifier's absence.
 
+**Two owners, one set of preconditions (#2598).** ent#534 gave the Workspace
+voice call the *first* branch of `onEscapeKeydown` — correct, because while a
+call is up the composer and the picker are inert and there is no turn to cancel.
+What was wrong is that the branch re-decided the preconditions instead of asking
+for them: it tested `voiceCallActive && event.key === 'Escape'` and nothing
+else. `defaultPrevented` is the protocol on this surface — #2582's file preview
+and delete confirm claim Escape in the capture phase precisely so they cannot
+destroy an in-flight turn, and that works only because `shouldCancelOnEscape`
+reads it. It was invisible to the branch above, so one keystroke closed the
+overlay **and** ended the call. `preventDefault()` cannot help where nothing
+reads it.
+
+The fix is a sibling rule, not a guard clause: `shouldEndCallOnEscape(event,
+{ callActive })` beside `shouldCancelOnEscape`, both starting from one private
+`ownsEscape(event)` — Escape, not composing, not already claimed. A bare
+`if (event.defaultPrevented) return` in the SFC would have fixed the reported
+symptom and left the next Escape owner free to make the same mistake, and it
+would have kept the decision in a component `vitest` cannot mount. The ordering
+property ent#534 cares about (the call is asked first) is unchanged and still
+pinned by `portalVoiceMode.spec.js`.
+
+It also closed a second instance of the same class that nobody had reported: the
+old branch ignored `isComposing`, so abandoning an IME candidate with Escape
+ended the call.
+
 ## The words come back without destroying a draft
 
 The AC asks that a restore "prepends or merges sensibly". Prepend is the
@@ -292,8 +317,9 @@ frontend change.
 
 ## Where the rules live
 
-`src/frontend/src/utils/turnCancel.js` — `shouldCancelOnEscape`, `restoreDraft`,
-`cancelOutcome`, `isTerminalStatus`. Pure, and shared by all three surfaces,
+`src/frontend/src/utils/turnCancel.js` — `shouldCancelOnEscape`,
+`shouldEndCallOnEscape` (#2598), `restoreDraft`, `cancelOutcome`,
+`isTerminalStatus`. Pure, and shared by all three surfaces,
 because `vitest.config.js` runs `environment: 'node'` with no mount harness: a
 rule decided inside an SFC is a rule no test can reach.
 
@@ -334,8 +360,10 @@ the same swap inline.
   statuses and real termination for `running`/`queued`; a missing execution as
   404; and an agent-side failure reworded for a client without naming the agent
   host.
-- `src/frontend/tests/unit/turnCancel.spec.js` (40) — every arm of the Escape
-  rule including IME and `defaultPrevented`; the restore/merge including
+- `src/frontend/tests/unit/turnCancel.spec.js` (48) — every arm of both Escape
+  rules including IME and `defaultPrevented`, and — from source — that the
+  Workspace's voice branch dispatches on `shouldEndCallOnEscape` rather than
+  re-deciding it (#2598: a predicate the branch bypasses passes its own tests); the restore/merge including
   idempotence and whitespace-only drafts; the three outcome shapes; and, from
   source, that all three surfaces import the shared rules rather than
   re-deciding them, capture and clear the id and the text together, register and

--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -654,7 +654,7 @@ import {
   speechErrorMessage,
   transcriptionErrorMessage,
 } from './portalUtils'
-import { shouldCancelOnEscape, restoreDraft, cancelOutcome, isNoopCancel } from '../../utils/turnCancel'
+import { shouldCancelOnEscape, shouldEndCallOnEscape, restoreDraft, cancelOutcome, isNoopCancel } from '../../utils/turnCancel'
 // ent#534: the voice CALL — the platform's real-time orb, in this chat. Its
 // rules live in their own pure module (vitest runs `environment: 'node'` with
 // no mount harness, so a rule kept in here is a rule no test can reach); this
@@ -1488,12 +1488,22 @@ async function deliver(text) {
 // itself is pure and lives in `utils/turnCancel.js`; what belongs here is the
 // list of things on THIS surface that Escape would otherwise be dismissing.
 // (`voiceMode` is a speak-replies TTS toggle, not an overlay. The ent#534 voice
-// call takes Escape for itself in the first branch below, before this rule runs,
-// so it is not on the list either.)
+// call is asked FIRST, below, and it is not on the overlay list because while a
+// call is up there is no turn to cancel.)
 function onEscapeKeydown(event) {
-  // ent#534: while a call is on, Escape ends the call — nothing else on this
-  // surface may own it then (the composer and the picker are inert).
-  if (voiceCallActive.value && event.key === 'Escape') {
+  // ent#534: while a call is on, Escape ends the call — the composer and the
+  // picker are inert, so nothing on this surface competes for it.
+  //
+  // #2598: asked through the shared rule, not re-decided here. This branch used
+  // to test `voiceCallActive.value && event.key === 'Escape'` and nothing else,
+  // so it ran ABOVE `shouldCancelOnEscape` while reading none of its
+  // preconditions — and #2582's overlays (the file preview, the delete confirm)
+  // claim Escape in the capture phase with `preventDefault()` exactly so they
+  // cannot destroy an in-flight turn. That protocol worked for the cancel rule,
+  // which reads `defaultPrevented`, and was invisible to this one: the overlay
+  // closed AND the call ended on a single keystroke. Both branches now start
+  // from the same `ownsEscape` preconditions, so they cannot drift again.
+  if (shouldEndCallOnEscape(event, { callActive: voiceCallActive.value })) {
     event.preventDefault()
     void endVoiceCall()
     return

--- a/src/frontend/src/utils/turnCancel.js
+++ b/src/frontend/src/utils/turnCancel.js
@@ -51,13 +51,56 @@ export function isNoopCancel(status) {
  * booleans — a menu open, a modal mounted, a picker showing.
  */
 export function shouldCancelOnEscape(event, { inFlight, cancelling, overlays = [] } = {}) {
-  if (!event || event.key !== 'Escape') return false
-  // A composed IME session uses Escape to abandon a candidate; taking it here
-  // would cancel the turn instead of the character.
-  if (event.isComposing) return false
-  if (event.defaultPrevented) return false
+  if (!ownsEscape(event)) return false
   if (!inFlight || cancelling) return false
   return !overlays.some(Boolean)
+}
+
+/**
+ * The three preconditions every Escape owner on these surfaces shares.
+ *
+ * Extracted in #2598 rather than left inline, because the bug was precisely
+ * that a SECOND Escape owner appeared and re-decided them — badly. `ent#534`
+ * gave the Workspace voice call the first branch of its handler, above
+ * `shouldCancelOnEscape` and reading none of this, so an overlay that claimed
+ * the keystroke in the capture phase with `preventDefault()` closed AND ended
+ * the call on one press. `preventDefault()` cannot help where nothing reads it.
+ *
+ *   - not Escape → not ours;
+ *   - a composed IME session uses Escape to abandon a candidate, so taking it
+ *     here acts on the turn instead of the character;
+ *   - `defaultPrevented` is the protocol on this surface: an overlay claims
+ *     Escape in the capture phase, and every owner downstream must yield.
+ */
+function ownsEscape(event) {
+  if (!event || event.key !== 'Escape') return false
+  if (event.isComposing) return false
+  if (event.defaultPrevented) return false
+  return true
+}
+
+/**
+ * Whether an Escape keydown should end an in-flight voice call (#2598).
+ *
+ * A sibling of `shouldCancelOnEscape`, not a special case of it: while a call
+ * is up the composer and the picker are inert, so there is no turn to cancel
+ * and no overlay list to consult — the only question is whether anything
+ * NEARER the keystroke already claimed it.
+ *
+ * It is a rule here rather than a guard clause in the SFC for the reason this
+ * whole module exists: `vitest.config.js` runs `environment: 'node'` with no
+ * mount harness, so a branch decided inside a component is a branch no test can
+ * reach — which is exactly how ent#534's version shipped able to ignore
+ * `defaultPrevented` and `isComposing` at once.
+ *
+ * The caller stays responsible for ordering: a call is the loudest thing on the
+ * surface, so this is asked FIRST and `shouldCancelOnEscape` only after it says
+ * no. Both now start from the same `ownsEscape` preconditions, so the two
+ * branches cannot drift apart again.
+ */
+export function shouldEndCallOnEscape(event, { callActive } = {}) {
+  if (!ownsEscape(event)) return false
+  return !!callActive
 }
 
 /**

--- a/src/frontend/tests/unit/portalVoiceMode.spec.js
+++ b/src/frontend/tests/unit/portalVoiceMode.spec.js
@@ -282,9 +282,18 @@ describe('modal: while the call is on, the chat is visible but inert', () => {
     expect(CODE).toMatch(/voiceMode\.value && ttsEnabled\.value && data\.response[\s\S]{0,120}!voiceCallActive\.value\) speak\(data\.response\)/)
   })
   it('Escape ends the call before the turn-cancel rule runs', () => {
+    // #2598 changed the SPELLING, not this property: the call is still asked
+    // first. The condition used to be the inline
+    // `voiceCallActive.value && event.key === 'Escape'`, which read none of the
+    // preconditions `shouldCancelOnEscape` reads — so an overlay that claimed
+    // Escape in the capture phase with `preventDefault()` closed AND ended the
+    // call. It now dispatches on the shared `shouldEndCallOnEscape` rule; the
+    // ORDERING assertion below is what ent#534 actually cares about and is
+    // unchanged.
     const esc = CODE.slice(CODE.indexOf('function onEscapeKeydown(event)'), CODE.indexOf('async function cancelTurn()'))
-    expect(esc.indexOf("voiceCallActive.value && event.key === 'Escape'")).toBeGreaterThan(-1)
-    expect(esc.indexOf("voiceCallActive.value && event.key === 'Escape'")).toBeLessThan(esc.indexOf('shouldCancelOnEscape(event'))
+    const call = esc.indexOf('shouldEndCallOnEscape(event, { callActive: voiceCallActive.value })')
+    expect(call).toBeGreaterThan(-1)
+    expect(call).toBeLessThan(esc.indexOf('shouldCancelOnEscape(event'))
     expect(esc).toContain('void endVoiceCall()')
   })
   it('the header line names the state and the way out; End always works', () => {

--- a/src/frontend/tests/unit/turnCancel.spec.js
+++ b/src/frontend/tests/unit/turnCancel.spec.js
@@ -13,7 +13,7 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import {
   shouldCancelOnEscape, restoreDraft, cancelOutcome, isTerminalStatus, TERMINAL_STATUSES,
-  isNoopCancel, NOOP_CANCEL_STATUSES,
+  isNoopCancel, NOOP_CANCEL_STATUSES, shouldEndCallOnEscape,
 } from '../../src/utils/turnCancel'
 
 const read = (rel) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8')
@@ -61,6 +61,62 @@ describe('Escape cancels a turn — and never hijacks anything else', () => {
   it('ignores every other key, and a missing event', () => {
     expect(shouldCancelOnEscape(esc({ key: 'Enter' }), { inFlight: true })).toBe(false)
     expect(shouldCancelOnEscape(null, { inFlight: true })).toBe(false)
+  })
+})
+
+describe('#2598 — a voice call owns Escape, but not against an overlay that already claimed it', () => {
+  // ent#534 gave the call the first branch of the Workspace's handler, ABOVE
+  // `shouldCancelOnEscape` and reading none of its preconditions. #2582's
+  // overlays (the file preview, the delete confirm) claim Escape in the capture
+  // phase with `preventDefault()` — the protocol every other Escape owner here
+  // honours — so the overlay closed AND the call ended on one keystroke.
+  //
+  // The fix is not a bare `if (event.defaultPrevented) return` in the SFC: the
+  // preconditions are the same three for both branches, so they belong in one
+  // place or they drift again. Hence a sibling predicate, not a guard clause.
+  it('ends the call on a plain Escape while a call is active', () => {
+    expect(shouldEndCallOnEscape(esc(), { callActive: true })).toBe(true)
+  })
+
+  it('does nothing when no call is active', () => {
+    expect(shouldEndCallOnEscape(esc(), { callActive: false })).toBe(false)
+  })
+
+  it('yields to an overlay that already claimed the keystroke', () => {
+    // The reported bug, stated as the rule: the preview/confirm calls
+    // preventDefault() in the capture phase, and this must see it.
+    expect(shouldEndCallOnEscape(esc({ defaultPrevented: true }), { callActive: true })).toBe(false)
+  })
+
+  it('yields to an IME composition, like every other Escape rule here', () => {
+    // Same class as the reported bug, one field over: a composed candidate is
+    // abandoned with Escape, and ending the call instead is the same "a branch
+    // that reads none of the preconditions" defect.
+    expect(shouldEndCallOnEscape(esc({ isComposing: true }), { callActive: true })).toBe(false)
+  })
+
+  it('ignores every other key, and a missing event', () => {
+    expect(shouldEndCallOnEscape(esc({ key: 'Enter' }), { callActive: true })).toBe(false)
+    expect(shouldEndCallOnEscape(null, { callActive: true })).toBe(false)
+    expect(shouldEndCallOnEscape(esc())).toBe(false)
+  })
+
+  it('the Workspace dispatches on the rule instead of re-deciding it in the SFC', () => {
+    // What only source can answer (this file's own convention): that the voice
+    // branch goes THROUGH the module. Without this the predicate can exist,
+    // pass its own tests, and be bypassed by the branch it was written for.
+    expect(workspace).toMatch(
+      /import \{[^}]*shouldEndCallOnEscape[^}]*\} from ['"][^'"]*utils\/turnCancel['"]/
+    )
+    expect(workspace).toContain('shouldEndCallOnEscape(event, { callActive: voiceCallActive.value })')
+    // and that the old hand-rolled condition is gone, not merely shadowed
+    expect(workspace).not.toMatch(/if \(voiceCallActive\.value && event\.key === 'Escape'\)/)
+  })
+
+  it('the stale comment that described the old ordering is gone', () => {
+    // The issue asks for this explicitly: the comment states an ordering that
+    // the fix changes, and a comment left behind is what the next reader trusts.
+    expect(workspace).not.toContain('takes Escape for itself in the first branch below')
   })
 })
 

--- a/src/frontend/tests/unit/turnCancel.spec.js
+++ b/src/frontend/tests/unit/turnCancel.spec.js
@@ -11,6 +11,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import { stripComments } from './helpers/stripComments'
 import {
   shouldCancelOnEscape, restoreDraft, cancelOutcome, isTerminalStatus, TERMINAL_STATUSES,
   isNoopCancel, NOOP_CANCEL_STATUSES, shouldEndCallOnEscape,
@@ -24,6 +25,15 @@ const chatInput = read('../../src/components/chat/ChatInput.vue')
 const portalStore = read('../../src/stores/clientPortal.js')
 
 const esc = (over = {}) => ({ key: 'Escape', isComposing: false, defaultPrevented: false, ...over })
+
+// #2598: this file reads sources RAW — every guard above predates the helper
+// and none of them would change meaning. The #2598 guards do: they assert both
+// that the new call is present and that the old condition is GONE, over a
+// region whose comments now quote the old condition verbatim to explain the
+// fix. Raw, the negative would be one explanatory sentence away from failing
+// spuriously, and the positive would pass on a comment alone if the call were
+// deleted — a vacuous guard. Stripped, both ask about code.
+const workspaceCode = stripComments(workspace)
 
 describe('Escape cancels a turn — and never hijacks anything else', () => {
   it('cancels while a turn is in flight', () => {
@@ -105,17 +115,19 @@ describe('#2598 — a voice call owns Escape, but not against an overlay that al
     // What only source can answer (this file's own convention): that the voice
     // branch goes THROUGH the module. Without this the predicate can exist,
     // pass its own tests, and be bypassed by the branch it was written for.
-    expect(workspace).toMatch(
+    expect(workspaceCode).toMatch(
       /import \{[^}]*shouldEndCallOnEscape[^}]*\} from ['"][^'"]*utils\/turnCancel['"]/
     )
-    expect(workspace).toContain('shouldEndCallOnEscape(event, { callActive: voiceCallActive.value })')
+    expect(workspaceCode).toContain('shouldEndCallOnEscape(event, { callActive: voiceCallActive.value })')
     // and that the old hand-rolled condition is gone, not merely shadowed
-    expect(workspace).not.toMatch(/if \(voiceCallActive\.value && event\.key === 'Escape'\)/)
+    expect(workspaceCode).not.toMatch(/voiceCallActive\.value && event\.key === 'Escape'/)
   })
 
   it('the stale comment that described the old ordering is gone', () => {
     // The issue asks for this explicitly: the comment states an ordering that
     // the fix changes, and a comment left behind is what the next reader trusts.
+    // The comment is the thing under test here, so this one reads the RAW
+    // source on purpose — stripping comments would make it vacuous.
     expect(workspace).not.toContain('takes Escape for itself in the first branch below')
   })
 })


### PR DESCRIPTION
## Summary

`onEscapeKeydown` handled the voice call in a branch **above** `shouldCancelOnEscape` that read none of its preconditions — so an overlay claiming Escape in the capture phase with `preventDefault()` closed **and** ended the call on one keystroke. `preventDefault()` cannot help where nothing reads it.

## Why not the one-liner

The issue offers `if (event.defaultPrevented) return` at the top. That is smaller and worse twice over:

- it fixes the reported symptom and leaves the **next** Escape owner free to re-decide the preconditions the same way;
- it keeps the decision inside an SFC `vitest` cannot mount (`environment: 'node'`, no `@vue/test-utils`) — which is exactly how the original shipped able to ignore `defaultPrevented` **and** `isComposing` at once.

So both branches now start from one private `ownsEscape(event)` in `utils/turnCancel.js` — Escape, not composing, not already claimed — and `shouldEndCallOnEscape(event, { callActive })` sits beside `shouldCancelOnEscape` as a sibling rule. Ordering is unchanged: the call is still asked first, because while a call is up the composer and the picker are inert and there is no turn to cancel.

## A second instance nobody reported

The old branch ignored `isComposing`, so abandoning an IME candidate with Escape ended the call. Same class, one field over; closed by the same change.

## Tests

`portalVoiceMode.spec.js` pinned the **literal** old condition and its ordering. The ordering is the property ent#534 actually cares about and is untouched, so that assertion is re-pointed at the new spelling rather than dropped. `turnCancel.spec.js` gains the rule's own arms plus a source guard that the branch dispatches **through** the rule — a predicate the branch bypasses passes its own tests.

Frontend suite: **2254 passed** (101 files).

## Docs

`chat-turn-cancellation.md` recorded this as a known residual; it now records the fix, why a guard clause was rejected, and the IME instance.

Fixes #2598

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdxGmvuKuqaWJZ6pKUgaUJ