### PR TITLE
fix(workspace): the sidebar date is flush right; an empty availability slot costs nothing (#2641)

### DIFF
--- a/docs/memory/feature-flows/workspace-sidebar-ia.md
+++ b/docs/memory/feature-flows/workspace-sidebar-ia.md
@@ -169,7 +169,27 @@ Three decisions worth keeping:
   start and stop; the design system's layout-stability rule forbids that, and the
   top-5 fold is #2159's design.
 * **Reserve the chip's footprint**, so a row does not reflow when an agent's
-  state changes between refreshes.
+  state changes between refreshes — but **for the list, not for every row**
+  (#2641). `availabilityChip()` answers null for everything except `stopped` and
+  `unavailable`, so on a fleet where everything is running — the normal case —
+  the 72px strip rendered empty on *every* row. That produced two visible
+  defects from one fact: the dates stopped 72px short of the row's right edge,
+  and 72px per row came out of the only element that wanted it, so names
+  truncated (`Chief ...`) beside a blank strip. `reservesAvailabilitySlot(rows)`
+  now decides it once per render, over the rows actually **rendered** — a
+  stopped agent hidden by search or the collapse limit must not reserve width on
+  a list that shows no chip. The whole `<span>` goes when nothing reserves it,
+  not just its width: a zero-width flex child still sits between the date and
+  the edge, and the row's `gap-2.5` would keep paying 10px for it.
+
+  Two properties survive the change and one cost is accepted. Uniform down the
+  list, so #2580's identical truncation point holds (a per-row reservation would
+  give a stopped row a different name width from its neighbours). Nothing moves
+  within a populated list — a second agent stopping, or one restarting while
+  another is still stopped, changes only that row's chip. The cost is the 0→1
+  transition: the first agent in view stopping reflows the list once, where
+  before it reflowed nothing. That is the honest price of not charging every row
+  for the empty case.
 
 `agentRowTitle()` carries the same reason in the row's `title`, so the state is
 reachable without relying on colour.
@@ -321,6 +341,7 @@ can actually see.
 | Test | Pins |
 |---|---|
 | `tests/unit/test_ent359_portal_chat_state.py` | cross-viewer isolation; kind/id key separation; email-case normalisation; no-cursor ⇒ nothing unread; only agent messages after the cursor count; re-reading clears; star and read don't overwrite each other; unstar keeps the cursor; validation; unknown ids don't 404; the cap bounds new rows but never freezes owned ones; mark-read at the cap is a no-op |
+| `src/frontend/tests/unit/portalSidebarDateFlushRight.spec.js` | #2641: the list-level reservation as a pure table (all-running reserves nothing; one stopped agent reserves for all; derived from `availabilityChip` rather than re-listing the states), that the template removes the ELEMENT rather than its width and computes over the rendered rows, and that #2580's date column is still fixed, right-aligned, `tabular-nums` and unconditional |
 | `src/frontend/tests/unit/portalSidebarIA.spec.js` | starred lifted out of every date group and appearing once; per-agent sums; a room crediting every participant; wordmark total; row-avatar cap and overflow |
 | `src/frontend/tests/unit/portalUndefinedCalls.spec.js` | (existing guard) the two new SFCs call nothing undefined |
 

--- a/src/frontend/src/components/portal/PortalSidebar.vue
+++ b/src/frontend/src/components/portal/PortalSidebar.vue
@@ -155,10 +155,24 @@
                The chip sets the expectation; the server's 502 is the honest
                refusal. Nothing is rendered for `ready` or `unknown`.
 
-               The slot's footprint is RESERVED (`min-w`, on the row always) so
-               a row does not reflow when an agent starts or stops between
-               refreshes — the same reason the roster is not re-sorted by this. -->
-          <span class="shrink-0 min-w-[4.5rem] flex justify-end">
+               The slot's footprint is RESERVED so a row does not reflow when an
+               agent starts or stops between refreshes — the same reason the
+               roster is not re-sorted by this.
+
+               #2641: the reservation is a property of the LIST, not of a row.
+               `availabilityChip` answers null for everything except `stopped`
+               and `unavailable`, so on a fleet where everything is running the
+               strip was empty on EVERY row — which is why the dates stopped
+               72px short of the right edge and the name was charged 72px for
+               nothing. Reserved on every row iff any VISIBLE row can show a
+               chip: uniform down the list, so #2580's identical truncation
+               point survives, and absent entirely when there is nothing to hold
+               space for, which puts the date flush against the row's edge.
+
+               The whole element goes, not just its width — a zero-width flex
+               child still sits between the date and the edge, and `gap-2.5` on
+               the row would keep paying 10px for it. -->
+          <span v-if="reserveAvailability" class="shrink-0 min-w-[4.5rem] flex justify-end">
             <BaseBadge v-if="chipFor(a)" :variant="chipFor(a).variant">{{ chipFor(a).label }}</BaseBadge>
           </span>
           <!-- #2424: the ask badge ent#364's comment above already promised.
@@ -320,6 +334,7 @@ import BaseBadge from '@/components/base/BaseBadge.vue'
 import { useClientPortalStore } from '@/stores/clientPortal'
 import {
   groupThreadsByDate, partitionStarred, unreadByAgent, totalUnread, availabilityChip,
+  reservesAvailabilitySlot,
   orderRosterAgents, agentRowMeta,
   asksByAgent, askBadgeTitle, agentRowTitle as buildAgentRowTitle,
   visibleAgentRows, AGENT_COLLAPSE_LIMIT,
@@ -473,6 +488,15 @@ const orderedRoster = computed(() => orderRosterAgents(
 const shownAgents = computed(() => (isSearching.value
   ? agentResults.value.visible
   : visibleAgentRows(orderedRoster.value, { expanded: agentsExpanded.value, askCounts: asksPerAgent.value })))
+
+// #2641: computed over `shownAgents` — the rows actually RENDERED — not over
+// the whole roster. A stopped agent hidden by search or by the collapse limit
+// would otherwise reserve width on a list that shows no chip, which is the
+// reported bug with extra steps. Declared after `shownAgents` rather than
+// beside `chipFor` so the dependency reads in source order; one pass per
+// render, beside `rowMeta`'s.
+const reserveAvailability = computed(() => reservesAvailabilitySlot(
+  shownAgents.value, { detailed: props.isPlatformSession }))
 
 // The one-line preview under the name (AC 6): the newest chat you have with
 // this agent. Null when there is nothing to show, so a row with no history

--- a/src/frontend/src/components/portal/portalUtils.js
+++ b/src/frontend/src/components/portal/portalUtils.js
@@ -898,6 +898,39 @@ export function availabilityChip(agent, { detailed = false } = {}) {
     }
 }
 
+/**
+ * #2641 — does THIS list of rows need the availability slot reserved at all?
+ *
+ * The slot's fixed footprint exists so a row does not reflow when an agent
+ * starts or stops between refreshes (#2196), and that is worth keeping. What
+ * was wrong is paying for it on every row unconditionally: `availabilityChip`
+ * returns null for every state except `stopped` and `unavailable`, so on a
+ * fleet where everything is running — the normal case — the strip is empty on
+ * EVERY row. That produced both halves of the reported defect at once: the
+ * dates stopped 72px short of the right edge, and 72px per row came out of the
+ * only element that wanted it, the name.
+ *
+ * The reservation is now a property of the LIST, not of a row: reserve on every
+ * row iff any row can actually show a chip. Uniform down the list, so #2580's
+ * identical truncation point survives, and free when there is nothing to hold
+ * space for.
+ *
+ * Takes the ROWS BEING RENDERED, not the whole roster — a stopped agent hidden
+ * by search or by the collapse limit would otherwise reserve width on a list
+ * that shows no chip, which is the original bug with extra steps.
+ *
+ * Residual, stated rather than discovered: the 0→1 transition (the first agent
+ * in view stops) reflows the whole list once, where before it reflowed nothing.
+ * That is the honest cost of not charging every row for the empty case, and it
+ * is the trade the issue delegates. Within a populated list nothing moves: a
+ * second agent stopping, or the first one restarting while another is still
+ * stopped, changes only that row's chip.
+ */
+export function reservesAvailabilitySlot(rows, opts = {}) {
+  if (!Array.isArray(rows)) return false
+  return rows.some((a) => availabilityChip(a, opts) !== null)
+}
+
 export const EMPTY_REASON_NO_PLAYBOOKS = 'No playbooks are available for this agent right now.'
 export const EMPTY_REASON_NO_PEERS = 'No other agents are shared with you.'
 export const EMPTY_REASON_NO_MENTIONABLE_PEERS =

--- a/src/frontend/tests/unit/portalSidebarDateFlushRight.spec.js
+++ b/src/frontend/tests/unit/portalSidebarDateFlushRight.spec.js
@@ -1,0 +1,145 @@
+/**
+ * #2641 — the sidebar date is flush right, and an empty availability slot costs
+ * the name nothing.
+ *
+ * The row was:
+ *
+ *   avatar · name (flex-1) · date (w-14) · availability (min-w-[4.5rem]) · badges
+ *
+ * `availabilityChip` returns null for every state except `stopped` and
+ * `unavailable`, so on a fleet where everything is running — the normal case —
+ * that 72px strip rendered EMPTY on every row. Both halves of the reported
+ * defect follow from one fact: the dates stopped 72px short of the row's right
+ * edge, and 72px per row was charged to the only element that wanted it, so
+ * names truncated (`Chief ...`) beside a blank strip.
+ *
+ * The reservation itself is worth keeping — it stops a row reflowing when an
+ * agent starts or stops between refreshes (#2196) — so it became a property of
+ * the LIST rather than of a row: reserve on every row iff any VISIBLE row can
+ * actually show a chip.
+ *
+ * This project has no component-mount harness (`package.json` carries no
+ * @vue/test-utils, jsdom or happy-dom; vitest runs `environment: 'node'`), which
+ * is why the decidable half lives in `portalUtils.js` and is genuinely executed
+ * here. The source assertions below are scoped to what only source can answer —
+ * that the template consumes the shared predicate, and that #2580's date column
+ * is still a fixed, right-aligned, always-rendered `tabular-nums` column.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+import {
+  availabilityChip,
+  reservesAvailabilitySlot,
+} from '../../src/components/portal/portalUtils'
+
+const read = (rel) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8')
+const SIDEBAR = read('../../src/components/portal/PortalSidebar.vue')
+
+const running = (name) => ({ name, availability: 'ready' })
+const stopped = (name) => ({ name, availability: 'stopped' })
+const gone = (name) => ({ name, availability: 'unavailable' })
+
+describe('#2641 — the slot is reserved for the LIST, not for every row', () => {
+  it('an all-running fleet reserves nothing', () => {
+    // The reported case. Every one of these yields a null chip, so holding
+    // 72px on each row buys a reflow that can never happen.
+    expect(reservesAvailabilitySlot([running('a'), running('b'), running('c')]))
+      .toBe(false)
+  })
+
+  it('one stopped agent makes the whole list reserve', () => {
+    // Uniform down the list, which is what keeps #2580's truncation point
+    // identical on every row — a per-row reservation would give the stopped
+    // row a different name width from its neighbours.
+    expect(reservesAvailabilitySlot([running('a'), stopped('b'), running('c')]))
+      .toBe(true)
+  })
+
+  it('an unavailable agent counts too — both chip states, not just stopped', () => {
+    expect(reservesAvailabilitySlot([running('a'), gone('b')])).toBe(true)
+  })
+
+  it('derives from availabilityChip rather than re-listing the states', () => {
+    // The predicate must not become a second copy of "which states get a chip".
+    // Anything the chip rule answers null for reserves nothing, including a
+    // state neither function has heard of yet.
+    for (const state of ['ready', 'unknown', 'something-new', '', null, undefined]) {
+      const agent = { name: 'x', availability: state }
+      expect(availabilityChip(agent)).toBeNull()
+      expect(reservesAvailabilitySlot([agent])).toBe(false)
+    }
+  })
+
+  it('is unmoved by the detailed flag, which only changes the WORDING', () => {
+    // An operator sees stopped-vs-no-container and a client sees one label for
+    // both; neither changes whether there is a chip, so neither may change
+    // whether space is held for one.
+    const rows = [running('a'), stopped('b')]
+    expect(reservesAvailabilitySlot(rows, { detailed: true })).toBe(true)
+    expect(reservesAvailabilitySlot(rows, { detailed: false })).toBe(true)
+  })
+
+  it('an empty or malformed list reserves nothing', () => {
+    expect(reservesAvailabilitySlot([])).toBe(false)
+    expect(reservesAvailabilitySlot(null)).toBe(false)
+    expect(reservesAvailabilitySlot(undefined)).toBe(false)
+    expect(reservesAvailabilitySlot('not a list')).toBe(false)
+  })
+})
+
+describe('#2641 — the template spends the predicate where it matters', () => {
+  it('the availability slot is conditional on it', () => {
+    expect(SIDEBAR).toMatch(
+      /<span\s+v-if="reserveAvailability"[^>]*min-w-\[4\.5rem\]/
+    )
+  })
+
+  it('removes the ELEMENT, not just its width', () => {
+    // A zero-width flex child still sits between the date and the row edge, and
+    // `gap-2.5` on the row would keep paying 10px for it — the date would still
+    // not be flush. So the guard is a `v-if`, never a conditional class.
+    const slot = SIDEBAR.slice(SIDEBAR.indexOf('reserveAvailability'))
+    expect(slot).not.toMatch(/:class="reserveAvailability/)
+  })
+
+  it('is computed over the RENDERED rows, not the whole roster', () => {
+    // A stopped agent hidden by search or by the collapse limit must not
+    // reserve width on a list that shows no chip — that is the reported bug
+    // with extra steps.
+    expect(SIDEBAR).toMatch(
+      /const reserveAvailability = computed\(\(\) => reservesAvailabilitySlot\(\s*shownAgents\.value/
+    )
+  })
+
+  it('the date column is the last thing before the conditional slot', () => {
+    // With nothing reserved after it, "flush right" is a consequence of the
+    // date being the final always-rendered element — the badges after it are
+    // content and have always been conditional.
+    const dateIdx = SIDEBAR.indexOf('w-14 text-right')
+    const slotIdx = SIDEBAR.indexOf('v-if="reserveAvailability"')
+    expect(dateIdx).toBeGreaterThan(-1)
+    expect(slotIdx).toBeGreaterThan(dateIdx)
+  })
+})
+
+describe('#2641 — #2580 is not regressed', () => {
+  it('the date column stays fixed-width, right-aligned and tabular', () => {
+    expect(SIDEBAR).toMatch(/class="shrink-0 w-14 text-right[^"]*tabular-nums"/)
+  })
+
+  it('the date span still renders on every row, with the v-if INSIDE it', () => {
+    // #2580's actual fix: the span disappearing on an agent you have never
+    // talked to moved the whole row's truncation point. The conditional is on
+    // the CONTENT, not on the column.
+    const m = SIDEBAR.match(/<span class="shrink-0 w-14 text-right[^"]*">\s*<template v-if="rowMeta\[a\.name\]\?\.time">/)
+    expect(m, 'the date column must be unconditional with the v-if inside').toBeTruthy()
+  })
+
+  it('the ask and waiting badges keep their conditional rendering', () => {
+    // AC: nothing else gains an unconditional footprint while we are here.
+    expect(SIDEBAR).toMatch(/v-if="askCountFor\(a\.name\)"/)
+    expect(SIDEBAR).toMatch(/v-if="waitingFor\(a\.name\)"/)
+  })
+})


### PR DESCRIPTION
The sidebar row held a 72px availability slot after the date column, on **every row, unconditionally**. `availabilityChip()` returns null for every state except `stopped` and `unavailable`, so on a fleet where everything is running — the normal case — that strip rendered **empty on every row**.

Both halves of the reported defect follow from that one fact: the dates stopped 72px short of the row's right edge, *and* 72px per row was charged to the only element that wanted it, so names truncated (`Chief ...`, `Marke ...`) beside a blank strip.

## The fix

The reservation is worth keeping — it stops a row reflowing when an agent starts or stops between refreshes (#2196). So it becomes a property of the **list**, not of a row:

```js
reservesAvailabilitySlot(rows, opts)   // portalUtils.js — pure
```

Reserve on every row **iff any visible row can actually show a chip**. Absent entirely otherwise, which puts the date flush against the row's edge.

Three details that are load-bearing rather than incidental:

- **Computed over the rows actually RENDERED**, not the whole roster. A stopped agent hidden by search or by the collapse limit would otherwise reserve width on a list that shows no chip — the reported bug with extra steps.
- **The whole `<span>` goes, not just its width.** A zero-width flex child still sits between the date and the row edge, and the row's `gap-2.5` would keep paying 10px for it, so the date still would not be flush. The guard is a `v-if`, never a conditional class — pinned by test.
- **The predicate derives from `availabilityChip`** rather than re-listing the two states, so it cannot drift into a second copy of "which states get a chip". A state neither function has heard of yet reserves nothing.

## Acceptance criteria

- [x] **Date flush against the row's right edge** on a fleet with no stopped or unavailable agents — the slot is not rendered at all.
- [x] **The empty slot costs no width.** Reserved only when the visible roster contains a chip-bearing agent.
- [x] **The name takes the space that frees up** — the freed 72px goes to the `flex-1` name block at every sidebar width.
- [x] **The no-reflow property survives** within a populated list: a second agent stopping, or one restarting while another is still stopped, changes only that row's chip. The roster is still not re-sorted by availability.
- [x] **#2580 is not regressed** — the date column stays `w-14 text-right tabular-nums`, rendered on every row with the `v-if` INSIDE it. Uniform reservation is precisely what preserves that when a chip does appear; a per-row reservation would give a stopped row a different name width from its neighbours.
- [x] **Ask and waiting badges keep their conditional rendering**; nothing else gained a footprint (asserted).
- [x] **Vitest coverage** for the chip-present and chip-absent cases.

## The one cost, stated rather than discovered later

The **0→1 transition** — the first agent in view stopping — reflows the list once, where before it reflowed nothing. That is the honest price of not charging every row for the empty case, and it is the trade the issue explicitly delegates ("*implementer's choice, but the empty case must not be charged to the name*"). The alternative the issue also names — putting the date last — makes it flush unconditionally but re-introduces the varying truncation point #2580 fixed, on every row that carries a chip. This keeps both properties everywhere except that single transition.

It is written into `workspace-sidebar-ia.md` beside the reservation's original rationale, not left in a commit message.

## Verification

- New `src/frontend/tests/unit/portalSidebarDateFlushRight.spec.js` — **13 passed**. The predicate as a pure table (all-running reserves nothing; one stopped reserves for all; `unavailable` counts too; derived-not-re-listed, including unknown/empty/null states; the `detailed` flag changes wording, never reservation; malformed input reserves nothing), plus source assertions for what only source can answer: the `v-if` (not a class), the `shownAgents` dependency, the ordering, and #2580's column.
- Full frontend suite: **112 files, 2516 tests, all passing.**
- `rawColorRatchet` + `loadingGateRatchet`: **14 passed** (this change adds no colour classes at all).
- `vite build` clean.

No component-mount harness exists in this project (`package.json` carries no @vue/test-utils, jsdom or happy-dom; vitest runs `environment: 'node'`), which is why the decidable half lives in `portalUtils.js` and is genuinely executed, and the source-regex assertions are scoped to the wiring — the same split `portalAvailabilityChip.spec.js` documents.

## Out of scope

`useColumnResize.js`'s `SIDEBAR_MIN = 200` — the issue names it as a side note. Freeing the 72px raises the effective floor for the name at every width without touching it.

Fixes #2641

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bd71qsYbFodvofba8P69eP
