### PR TITLE
fix(workspace): the rail's maximum comes from the viewport, not a constant (#2617)

### DIFF
--- a/docs/memory/requirements/core-agent.md
+++ b/docs/memory/requirements/core-agent.md
@@ -2462,6 +2462,22 @@ to localStorage in the clear.
   same floor `fitsThreeColumns` asks about, a drag can no longer break the fit
   at all — what remains for auto-collapse is the case it was written for, a
   window too narrow for three columns at their minima.
+- **The sidebar's ceiling is billed against what the rail RENDERS, and the
+  handle reports the effective width (#2617 review).** Two mistakes of one shape,
+  both caught in review. `sidebarMax` was measured against `effectiveRail`, which
+  carries no open/closed term, so a COLLAPSED rail was still charged at its full
+  open width — at 1280px the ceiling landed at 416 while 752 was free, *below*
+  the `SIDEBAR_MAX = 480` constant being replaced, so a narrow window came out
+  worse than before the change. It is measured against `railWidth` (the rendered
+  width: effective when open, the 48px strip when closed). And the two handles
+  bound `:value` to the DESIRE while `:max` was the derived ceiling — which lets
+  `aria-valuenow` exceed `aria-valuemax`, and makes `startValue` begin every drag
+  at a position the clamp discards, so the handle is inert for the whole distance
+  between the desire and the ceiling (several hundred px on a laptop). They bind
+  `columns.effectiveSidebar` / `columns.effectiveRail`. The desire still survives
+  untouched in storage and returns when there is room; a drag from a clamped
+  position deliberately replaces it, because the person is moving the handle they
+  can see.
 - The message cap has ONE definition (`--ws-message-max`, 1100px, wider than the
   `max-w-4xl` it replaces) and `PortalSkeleton` shares it: the skeleton exists to
   hold the footprint the loaded surface lands on (#2540), so a placeholder capped

--- a/docs/memory/requirements/core-agent.md
+++ b/docs/memory/requirements/core-agent.md
@@ -2428,11 +2428,40 @@ no such record gets one `client` bucket, since that browser holds one portal
 token at a time. **Never derived from token material** — the key is written back
 to localStorage in the clear.
 
-- Clamps: sidebar 200–480, side panel 280–560, and the conversation has a 480px
-  floor. When the viewport cannot fit all three the **rail auto-collapses** —
-  the conversation is never the column that gets squeezed — checked on window
-  resize as well as on drag, because a window dragged narrower is the same
-  situation arrived at differently.
+- Clamps: sidebar and side panel have pixel MINIMA (200 / 280 — where a column
+  stops being able to do its job) and **viewport-derived MAXIMA** (#2617). When
+  the viewport cannot fit all three the **rail auto-collapses** — the
+  conversation is never the column that gets squeezed — checked on window resize
+  as well as on drag, because a window dragged narrower is the same situation
+  arrived at differently.
+- **The maxima are derived, not constants (#2617, 2026-09-09).** They shipped as
+  `SIDEBAR_MAX = 480` / `RAIL_MAX = 560`, applied unconditionally, which made the
+  share a person could give a column *shrink* as their screen grew: the rail
+  stopped at ~22% of a 2560px display. Reported by the operator — *"it does not
+  go bigger than like 20% or something. I should be able to make it whatever I
+  want, say half the screen width."* — and it contradicted the file's own stated
+  intent ("deliberately generous — this is a person arranging their own screen"),
+  which an absolute pixel number cannot express. The replacement was already in
+  the file: a column may take everything left after its neighbour and
+  `CONVERSATION_MIN`, so the conversation's readable floor is the one rule that
+  stops a drag, at every screen size. `railMaxFor(viewport, sidebar)` /
+  `sidebarMaxFor(viewport, rail)`; both floored at the column's own minimum,
+  because a ceiling under the floor would invert the clamp and pin the column to
+  the *maximum*. The sidebar got the same treatment though nobody had hit its
+  cap: leaving one derived and one fixed would leave the next reader guessing
+  which rule the file follows.
+- **Desired width and effective width are two numbers (#2617, AC 4).** What is
+  stored and dragged is what the person asked for; what the grid renders is
+  `min(desired, derived max)`. So a layout arranged on a 2560px monitor is
+  clamped down for display on a laptop and comes back intact on the monitor —
+  clamping at the persistence boundary instead would have written the laptop's
+  ceiling over their choice on the first `commit()`, which is "silently
+  discarded" wearing a clamp. `enforceFit` therefore tests the EFFECTIVE widths:
+  testing the desired one would collapse a rail that fits, purely because a
+  wider one was once arranged elsewhere. Since the drag is now bounded by the
+  same floor `fitsThreeColumns` asks about, a drag can no longer break the fit
+  at all — what remains for auto-collapse is the case it was written for, a
+  window too narrow for three columns at their minima.
 - The message cap has ONE definition (`--ws-message-max`, 1100px, wider than the
   `max-w-4xl` it replaces) and `PortalSkeleton` shares it: the skeleton exists to
   hold the footprint the loaded surface lands on (#2540), so a placeholder capped

--- a/src/frontend/src/composables/useColumnResize.js
+++ b/src/frontend/src/composables/useColumnResize.js
@@ -248,14 +248,24 @@ export function useColumnResize({ railOpen, setRailOpen = () => {} } = {}) {
   // that looks nothing like its cause.
   const railMax = computed(() => railMaxFor(viewportWidth.value, sidebar.value))
   const effectiveRail = computed(() => Math.min(railOpenWidth.value, railMax.value))
-  // The sidebar's ceiling is measured against what the rail is ACTUALLY taking,
-  // not what it would like to take: otherwise a rail whose desired width the
-  // viewport cannot honour would keep charging the sidebar for space nobody is
-  // using.
-  const sidebarMax = computed(() => sidebarMaxFor(viewportWidth.value, effectiveRail.value))
-  const effectiveSidebar = computed(() => Math.min(sidebar.value, sidebarMax.value))
-
+  // What the rail is RENDERING: its effective width when open, the fixed strip
+  // when collapsed. Declared here rather than after the sidebar's ceiling
+  // because that ceiling is measured against it.
   const railWidth = computed(() => (railOpen?.value ? effectiveRail.value : RAIL_COLLAPSED))
+  // The sidebar's ceiling is measured against what the rail is ACTUALLY taking
+  // — `railWidth`, which carries the open/closed state — not against the width
+  // it would like to take if it were open. Two ways to get this wrong, and the
+  // second one shipped:
+  //
+  //   * `railOpenWidth` (the desire) would keep charging the sidebar for space
+  //     a rail the viewport cannot honour is not using;
+  //   * `effectiveRail` looks like the fix and is only two thirds of it — it
+  //     has no `railOpen` term, so a COLLAPSED rail is still billed at its full
+  //     open width. At 1280px that put the ceiling at 416 while 752 was
+  //     genuinely free, which is BELOW the `SIDEBAR_MAX = 480` constant this
+  //     replaces: a narrow window would have come out worse than before.
+  const sidebarMax = computed(() => sidebarMaxFor(viewportWidth.value, railWidth.value))
+  const effectiveSidebar = computed(() => Math.min(sidebar.value, sidebarMax.value))
 
   // What the grid reads. Kept as one object so `Portal.vue` binds a single
   // `:style` and cannot set one variable and forget the other.

--- a/src/frontend/src/composables/useColumnResize.js
+++ b/src/frontend/src/composables/useColumnResize.js
@@ -22,15 +22,63 @@ export const RAIL_DEFAULT = 384
 // The collapsed rail is a fixed strip, not a resizable column (ent#474's 48px).
 export const RAIL_COLLAPSED = 48
 
-// Clamps. The maxima are deliberately generous — this is a person arranging
-// their own screen, not a layout that needs defending from them — and the
-// minima are where a column stops being able to do its job: a sidebar narrower
-// than this truncates every agent name to nothing, and a rail narrower than
-// this cannot lay out the Work card's step list.
+// Clamps. The minima are where a column stops being able to do its job: a
+// sidebar narrower than this truncates every agent name to nothing, and a rail
+// narrower than this cannot lay out the Work card's step list.
 export const SIDEBAR_MIN = 200
-export const SIDEBAR_MAX = 480
 export const RAIL_MIN = 280
-export const RAIL_MAX = 560
+
+// #2617: the MAXIMA are derived from the viewport, not fixed pixels.
+//
+// They used to be `SIDEBAR_MAX = 480` / `RAIL_MAX = 560`, applied
+// unconditionally — which meant the wider the display, the SMALLER the share a
+// person could give a column. On a 2560px screen the rail stopped at ~22%,
+// reported by the operator as "it does not go bigger than like 20% or
+// something. I should be able to make it whatever I want, say half the screen
+// width." That is the opposite of what a resize handle is for, and it
+// contradicted this block's own stated intent ("deliberately generous — this is
+// a person arranging their own screen, not a layout that needs defending from
+// them"), which an absolute pixel number cannot express.
+//
+// The right bound was already in this file. `CONVERSATION_MIN` is the readable
+// floor for the message column, and `fitsThreeColumns` already treats it as the
+// thing a layout must not break. So a column may take everything left after the
+// OTHER two: the conversation's floor is the one rule that stops a drag, at
+// every screen size, and it protects a narrow window exactly as before.
+//
+// The two are symmetric on purpose. `SIDEBAR_MAX` had the same shape of problem
+// (AC 7) — nobody had hit it, but keeping one derived and one fixed would leave
+// the next reader guessing which rule this file follows.
+
+export function railMaxFor(viewportWidth, sidebarWidth) {
+  return columnMaxFor(viewportWidth, sidebarWidth, RAIL_MIN)
+}
+
+export function sidebarMaxFor(viewportWidth, railWidth) {
+  return columnMaxFor(viewportWidth, railWidth, SIDEBAR_MIN)
+}
+
+/**
+ * The space one column may take: the viewport, less its neighbour, less the
+ * conversation's floor.
+ *
+ * Never returns less than the column's own minimum. A maximum below the minimum
+ * would invert the clamp — `Math.min(max, Math.max(min, px))` would then pin
+ * the column to the MAXIMUM and quietly break the floor that minimum exists to
+ * hold. On a viewport with no room for three columns the auto-collapse rule
+ * (`fitsThreeColumns` → `enforceFit`) is what applies, not a negative ceiling.
+ *
+ * A viewport of 0 — no `window`, a test, an element not yet laid out — is not a
+ * measurement, so it yields the minimum rather than a number derived from
+ * nothing. Callers that can be reached before layout use the stored width
+ * directly; see `railWidth`.
+ */
+function columnMaxFor(viewportWidth, otherWidth, ownMin) {
+  const vp = Math.floor(Number(viewportWidth) || 0)
+  const other = Math.round(Number(otherWidth) || 0)
+  if (vp <= 0) return ownMin
+  return Math.max(ownMin, vp - other - CONVERSATION_MIN)
+}
 
 // The conversation's floor. Below this a thread stops being readable, so the
 // AC's rule applies: the rail auto-collapses rather than the conversation being
@@ -96,12 +144,16 @@ export function resolveLayoutIdentity(storage) {
   return 'anon'
 }
 
-export function clampSidebar(px) {
-  return Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, Math.round(px)))
+// #2617: the ceiling is passed IN rather than read from a constant or a global,
+// which is what keeps these pure and testable at several viewport widths. An
+// omitted `max` means "no viewport-derived ceiling, floor only" — the shape the
+// persistence path needs, for the reason on `readStored`.
+export function clampSidebar(px, max = Infinity) {
+  return Math.min(max, Math.max(SIDEBAR_MIN, Math.round(Number(px) || 0)))
 }
 
-export function clampRail(px) {
-  return Math.min(RAIL_MAX, Math.max(RAIL_MIN, Math.round(px)))
+export function clampRail(px, max = Infinity) {
+  return Math.min(max, Math.max(RAIL_MIN, Math.round(Number(px) || 0)))
 }
 
 /**
@@ -120,6 +172,12 @@ export function readStored(storage, userKey) {
     if (!raw) return null
     const v = JSON.parse(raw)
     if (!v || typeof v !== 'object') return null
+    // #2617 (AC 4): floored, never CAPPED to the current viewport. What is
+    // stored is the width the person asked for; the cap is applied where the
+    // number is USED (`railWidth`), so a layout arranged on a 2560px monitor
+    // comes back intact on that monitor after a stint on a laptop. Clamping
+    // here would have written the laptop's ceiling back over their choice on
+    // the first `commit()`, which is "silently discarded" wearing a clamp.
     return {
       sidebar: Number.isFinite(v.sidebar) ? clampSidebar(v.sidebar) : SIDEBAR_DEFAULT,
       rail: Number.isFinite(v.rail) ? clampRail(v.rail) : RAIL_DEFAULT,
@@ -172,12 +230,37 @@ export function useColumnResize({ railOpen, setRailOpen = () => {} } = {}) {
   // fixed strip and never overwrites this number.
   const railOpenWidth = ref(stored?.rail ?? RAIL_DEFAULT)
 
-  const railWidth = computed(() => (railOpen?.value ? railOpenWidth.value : RAIL_COLLAPSED))
+  // #2617: the maxima depend on the viewport, so the viewport has to be
+  // reactive. Seeded synchronously at setup for the same reason the stored
+  // widths are — a first paint at the wrong ceiling is a visible jump — and
+  // updated by the `resize` listener the auto-collapse rule already installs,
+  // so this adds no second listener.
+  const viewportWidth = ref(typeof window !== 'undefined' ? window.innerWidth : 0)
+
+  // The DESIRED widths are `sidebar` / `railOpenWidth`; these are what the
+  // layout may actually give them right now. Splitting the two is the whole of
+  // AC 4: a width arranged on a wide monitor is clamped for display on a narrow
+  // one and comes back when there is room, because the desired number was never
+  // overwritten.
+  // Declared in dependency order. `computed` bodies are lazy, so the reverse
+  // would also run — but a reader should not have to prove that to themselves,
+  // and a later refactor that reads one of these eagerly would hit a TDZ error
+  // that looks nothing like its cause.
+  const railMax = computed(() => railMaxFor(viewportWidth.value, sidebar.value))
+  const effectiveRail = computed(() => Math.min(railOpenWidth.value, railMax.value))
+  // The sidebar's ceiling is measured against what the rail is ACTUALLY taking,
+  // not what it would like to take: otherwise a rail whose desired width the
+  // viewport cannot honour would keep charging the sidebar for space nobody is
+  // using.
+  const sidebarMax = computed(() => sidebarMaxFor(viewportWidth.value, effectiveRail.value))
+  const effectiveSidebar = computed(() => Math.min(sidebar.value, sidebarMax.value))
+
+  const railWidth = computed(() => (railOpen?.value ? effectiveRail.value : RAIL_COLLAPSED))
 
   // What the grid reads. Kept as one object so `Portal.vue` binds a single
   // `:style` and cannot set one variable and forget the other.
   const gridStyle = computed(() => ({
-    '--ws-sidebar': `${sidebar.value}px`,
+    '--ws-sidebar': `${effectiveSidebar.value}px`,
     '--ws-rail': `${railWidth.value}px`,
     '--ws-message-max': `${MESSAGE_MAX}px`,
   }))
@@ -195,12 +278,12 @@ export function useColumnResize({ railOpen, setRailOpen = () => {} } = {}) {
   }
 
   function resizeSidebar(px) {
-    sidebar.value = clampSidebar(px)
+    sidebar.value = clampSidebar(px, sidebarMax.value)
     commit()
   }
 
   function resizeRail(px) {
-    railOpenWidth.value = clampRail(px)
+    railOpenWidth.value = clampRail(px, railMax.value)
     commit()
   }
 
@@ -218,9 +301,21 @@ export function useColumnResize({ railOpen, setRailOpen = () => {} } = {}) {
   // conversation is never the column that gets squeezed. Checked on resize as
   // well as on drag, because a window someone dragged narrower is the same
   // situation arrived at differently.
-  function enforceFit(viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 0) {
-    if (!viewportWidth || !railOpen?.value) return
-    if (!fitsThreeColumns(viewportWidth, sidebar.value, railOpenWidth.value)) {
+  function enforceFit(vw = typeof window !== 'undefined' ? window.innerWidth : 0) {
+    if (!vw) return
+    // #2617: record the viewport even when the rail is closed — the maxima are
+    // derived from it, and a window resized while the rail was collapsed would
+    // otherwise reopen it against a stale ceiling.
+    viewportWidth.value = vw
+    if (!railOpen?.value) return
+    // Tested against the EFFECTIVE width, not the desired one. Since the drag
+    // is now bounded by the same conversation floor this asks about, a drag can
+    // no longer break the fit at all; what remains is the case this rule was
+    // written for — a window narrowed until even `RAIL_MIN` will not fit
+    // beside the conversation's floor. Testing the desired width here would
+    // collapse a rail that fits, purely because the person once arranged a
+    // wider one on a bigger screen.
+    if (!fitsThreeColumns(vw, effectiveSidebar.value, effectiveRail.value)) {
       setRailOpen(false)
     }
   }
@@ -252,6 +347,15 @@ export function useColumnResize({ railOpen, setRailOpen = () => {} } = {}) {
     sidebar,
     railOpenWidth,
     railWidth,
+    // #2617: the live ceilings. Exposed as computeds rather than folded into
+    // `limits` because a template reads `columns.railMax.value` — a ref nested
+    // inside a plain object is NOT auto-unwrapped, and `limits.rail.max` would
+    // have silently rendered `[object Object]` into `aria-valuemax`.
+    railMax,
+    sidebarMax,
+    effectiveRail,
+    effectiveSidebar,
+    viewportWidth,
     gridStyle,
     resizeSidebar,
     resizeRail,
@@ -260,8 +364,11 @@ export function useColumnResize({ railOpen, setRailOpen = () => {} } = {}) {
     enforceFit,
     refreshIdentity,
     limits: {
-      sidebar: { min: SIDEBAR_MIN, max: SIDEBAR_MAX, default: SIDEBAR_DEFAULT },
-      rail: { min: RAIL_MIN, max: RAIL_MAX, default: RAIL_DEFAULT },
+      // The MINIMA and defaults are still constants. The maxima moved out to
+      // `railMax` / `sidebarMax` above (#2617) and are deliberately absent
+      // here rather than left as stale numbers a caller could still read.
+      sidebar: { min: SIDEBAR_MIN, default: SIDEBAR_DEFAULT },
+      rail: { min: RAIL_MIN, default: RAIL_DEFAULT },
     },
   }
 }

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -138,8 +138,17 @@
           @sign-out="onSignOut"
         />
       </div>
+      <!-- #2617: `:value` is the EFFECTIVE width, not the desired one. The two
+           are different numbers on a viewport that cannot honour a width
+           arranged on a bigger screen, and a handle that reports the desire
+           would emit `aria-valuenow` above its own `aria-valuemax` and start
+           every drag from a position the clamp immediately discards — the
+           handle sits still for the first few hundred px of travel. The desire
+           survives in `columns.sidebar` / `columns.railOpenWidth` and comes
+           back when there is room; a drag from a clamped position deliberately
+           replaces it, because the person is moving the handle they can see. -->
       <ColumnResizeHandle
-        :value="columns.sidebar.value"
+        :value="columns.effectiveSidebar.value"
         :min="columns.limits.sidebar.min"
         :max="columns.sidebarMax.value"
         label="Resize the sidebar"
@@ -434,7 +443,7 @@
            handle rather than a second one. -->
       <ColumnResizeHandle
         v-if="thirdColumnResizable"
-        :value="columns.railOpenWidth.value"
+        :value="columns.effectiveRail.value"
         :min="columns.limits.rail.min"
         :max="columns.railMax.value"
         label="Resize the side panel"

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -141,7 +141,7 @@
       <ColumnResizeHandle
         :value="columns.sidebar.value"
         :min="columns.limits.sidebar.min"
-        :max="columns.limits.sidebar.max"
+        :max="columns.sidebarMax.value"
         label="Resize the sidebar"
         side="left"
         testid="ws-handle-sidebar"
@@ -436,7 +436,7 @@
         v-if="thirdColumnResizable"
         :value="columns.railOpenWidth.value"
         :min="columns.limits.rail.min"
-        :max="columns.limits.rail.max"
+        :max="columns.railMax.value"
         label="Resize the side panel"
         side="right"
         testid="ws-handle-rail"

--- a/src/frontend/tests/unit/workspaceColumnMaxFromViewport.spec.js
+++ b/src/frontend/tests/unit/workspaceColumnMaxFromViewport.spec.js
@@ -169,6 +169,13 @@ describe('#2617 — the composable exposes the derived ceilings', () => {
     expect(shell).toMatch(/:max="columns\.railMax\.value"/)
     expect(shell).toMatch(/:max="columns\.sidebarMax\.value"/)
     expect(shell).not.toMatch(/limits\.(rail|sidebar)\.max/)
+    // ...and `:value` is the EFFECTIVE width, so `aria-valuenow` cannot exceed
+    // the `aria-valuemax` beside it and a drag starts where the handle is. The
+    // behavioural half of this is in the driving block below; this pins the
+    // PAIRING, which lives in the template and nowhere else.
+    expect(shell).toMatch(/:value="columns\.effectiveSidebar\.value"/)
+    expect(shell).toMatch(/:value="columns\.effectiveRail\.value"/)
+    expect(shell).not.toMatch(/:value="columns\.(sidebar|railOpenWidth)\.value"/)
   })
 
   it('the viewport is recorded even while the rail is collapsed', async () => {
@@ -192,5 +199,151 @@ describe('#2617 — the composable exposes the derived ceilings', () => {
       ), 'utf8',
     )
     expect(src).toMatch(/fitsThreeColumns\(vw, effectiveSidebar\.value, effectiveRail\.value\)/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The composable itself, driven — not scanned
+// ---------------------------------------------------------------------------
+//
+// Every assertion above this line is either a pure helper or a regex over the
+// source. That is why the collapsed-rail ceiling shipped wrong: the AC-4 case
+// recomputed its own expectation from `railMaxFor` rather than reading what
+// `useColumnResize` actually derives, so the composable's own wiring was never
+// executed. It can be: `effectScope` gives it a reactive owner, and the two
+// lifecycle hooks are the only thing it wants a component for.
+
+describe('#2617 — driving useColumnResize', () => {
+  async function drive({ viewport = LAPTOP, railOpen = true, stored = null } = {}) {
+    const { effectScope, ref } = await import('vue')
+    const { useColumnResize } = await import('@/composables/useColumnResize')
+
+    const prevWindow = globalThis.window
+    const store = fakeStorage(
+      stored ? { 'trinity-workspace-columns:anon': JSON.stringify(stored) } : {},
+    )
+    globalThis.window = {
+      innerWidth: viewport,
+      localStorage: store,
+      addEventListener() {},
+      removeEventListener() {},
+    }
+    // `onMounted` outside a component is a no-op with a dev warning; the hooks
+    // only install the resize listener, which these tests drive by hand.
+    const warn = console.warn
+    console.warn = () => {}
+
+    const open = ref(railOpen)
+    const scope = effectScope()
+    let columns
+    try {
+      columns = scope.run(() => useColumnResize({ railOpen: open, setRailOpen: (v) => { open.value = v } }))
+    } finally {
+      console.warn = warn
+      globalThis.window = prevWindow
+    }
+    return { columns, open, scope, store }
+  }
+
+  it('bills the sidebar for the COLLAPSED strip when the rail is closed', async () => {
+    // The finding: `sidebarMax` read `effectiveRail`, which carries no
+    // `railOpen` term, so a closed rail was charged at its full open width.
+    const { columns } = await drive({ viewport: LAPTOP, railOpen: false })
+    expect(columns.railWidth.value).toBe(48)
+    expect(columns.sidebarMax.value).toBe(LAPTOP - 48 - CONVERSATION_MIN) // 752
+  })
+
+  it('does not regress the narrow window below the constant it replaces', async () => {
+    // 416 was the number this shipped with — under `SIDEBAR_MAX = 480`, so a
+    // laptop came out WORSE than before #2617. AC 3 is that it does not.
+    const { columns } = await drive({ viewport: LAPTOP, railOpen: false })
+    expect(columns.sidebarMax.value).toBeGreaterThanOrEqual(480)
+  })
+
+  it('bills the sidebar for the rail\'s real width when it is open', async () => {
+    const { columns } = await drive({ viewport: LAPTOP, railOpen: true })
+    expect(columns.railWidth.value).toBe(RAIL_DEFAULT)
+    expect(columns.sidebarMax.value).toBe(LAPTOP - RAIL_DEFAULT - CONVERSATION_MIN)
+  })
+
+  it('collapsing the rail widens the sidebar\'s ceiling, reopening narrows it', async () => {
+    const { columns, open } = await drive({ viewport: LAPTOP, railOpen: true })
+    const openCeiling = columns.sidebarMax.value
+    open.value = false
+    expect(columns.sidebarMax.value).toBeGreaterThan(openCeiling)
+    open.value = true
+    expect(columns.sidebarMax.value).toBe(openCeiling)
+  })
+
+  it('never lets the three columns exceed the viewport, either way round', async () => {
+    for (const railOpen of [true, false]) {
+      const { columns } = await drive({ viewport: LAPTOP, railOpen })
+      const total = columns.sidebarMax.value + columns.railWidth.value + CONVERSATION_MIN
+      expect(total).toBeLessThanOrEqual(LAPTOP)
+    }
+  })
+
+  it('keeps the desired width while showing the clamped one (AC 4)', async () => {
+    // Arranged on a wide monitor, viewed on a laptop.
+    const { columns } = await drive({
+      viewport: LAPTOP, railOpen: true, stored: { sidebar: 700, rail: 900 },
+    })
+    expect(columns.sidebar.value).toBe(700)              // the desire survives
+    expect(columns.railOpenWidth.value).toBe(900)
+    expect(columns.effectiveRail.value).toBe(columns.railMax.value)
+    expect(columns.effectiveSidebar.value).toBe(columns.sidebarMax.value)
+    expect(columns.effectiveSidebar.value).toBeLessThan(700)
+  })
+
+  it('reports a width the handle can legally announce (aria-valuenow <= max)', async () => {
+    // The second finding: the handles bound `:value` to the DESIRE and `:max`
+    // to the derived ceiling, so `aria-valuenow` could exceed `aria-valuemax`
+    // and `startValue` began every drag at a position the clamp discards.
+    const { columns } = await drive({
+      viewport: LAPTOP, railOpen: true, stored: { sidebar: 700, rail: 900 },
+    })
+    expect(columns.effectiveSidebar.value).toBeLessThanOrEqual(columns.sidebarMax.value)
+    expect(columns.effectiveRail.value).toBeLessThanOrEqual(columns.railMax.value)
+  })
+
+  it('a drag from a clamped position moves immediately; the desire would not', async () => {
+    // Arranged on a 2560px screen, viewed on a 1600px one, so the rail's
+    // desire is far above its ceiling and the ceiling is above its floor.
+    const { columns } = await drive({
+      viewport: 1600, railOpen: true, stored: { sidebar: SIDEBAR_DEFAULT, rail: 2000 },
+    })
+    expect(columns.railOpenWidth.value).toBe(2000)
+    expect(columns.effectiveRail.value).toBe(columns.railMax.value)
+    expect(columns.effectiveRail.value).toBeGreaterThan(RAIL_MIN)
+
+    // What ColumnResizeHandle does with whatever `:value` it is given:
+    // startValue = props.value, then every move is clamped.
+    const drag = (startValue, delta) =>
+      Math.min(columns.railMax.value, Math.max(RAIL_MIN, startValue - delta))
+
+    // Bound to the EFFECTIVE width — the handle tracks the pointer from pixel one.
+    expect(drag(columns.effectiveRail.value, 1)).toBe(columns.effectiveRail.value - 1)
+
+    // Bound to the DESIRE, as it shipped: the handle is inert for the whole
+    // distance between the desire and the ceiling.
+    const dead = columns.railOpenWidth.value - columns.railMax.value
+    expect(dead).toBeGreaterThan(300)
+    expect(drag(columns.railOpenWidth.value, 1)).toBe(columns.railMax.value)
+    expect(drag(columns.railOpenWidth.value, dead)).toBe(columns.railMax.value)
+  })
+
+  it('records the viewport on resize even while the rail is collapsed', async () => {
+    const { columns } = await drive({ viewport: LAPTOP, railOpen: false })
+    const before = columns.sidebarMax.value
+    columns.enforceFit(WIDE)
+    expect(columns.viewportWidth.value).toBe(WIDE)
+    expect(columns.sidebarMax.value).toBeGreaterThan(before)
+  })
+
+  it('collapses the rail when the window can no longer fit three columns', async () => {
+    const { columns, open } = await drive({ viewport: DESK, railOpen: true })
+    expect(open.value).toBe(true)
+    columns.enforceFit(600)
+    expect(open.value).toBe(false)
   })
 })

--- a/src/frontend/tests/unit/workspaceColumnMaxFromViewport.spec.js
+++ b/src/frontend/tests/unit/workspaceColumnMaxFromViewport.spec.js
@@ -1,0 +1,196 @@
+/**
+ * #2617 — the rail's maximum comes from the viewport, not from a constant.
+ *
+ * `RAIL_MAX = 560` was applied unconditionally, so the wider the display the
+ * SMALLER the share a person could give the column: ~22% of a 2560px screen.
+ * The operator's report is the whole specification — *"it does not go bigger
+ * than like 20% or something. I should be able to make it whatever I want, say
+ * half the screen width."*
+ *
+ * The bound that replaces it was already in the file: `CONVERSATION_MIN`, the
+ * readable floor `fitsThreeColumns` already refuses to break. A column may take
+ * everything left after its neighbour and that floor — which is generous on a
+ * wide screen and unchanged on a narrow one, because it is the same rule at
+ * both ends.
+ *
+ * The subtle half is AC 4, and it has its own section below: a width arranged
+ * on a big monitor must survive a stint on a laptop. That needs the DESIRED
+ * width and the width the layout can currently give to be two different
+ * numbers, which is what `railOpenWidth` vs `effectiveRail` is.
+ */
+import { describe, it, expect } from 'vitest'
+
+import {
+  railMaxFor,
+  sidebarMaxFor,
+  clampRail,
+  clampSidebar,
+  fitsThreeColumns,
+  readStored,
+  writeStored,
+  RAIL_MIN,
+  RAIL_DEFAULT,
+  SIDEBAR_MIN,
+  SIDEBAR_DEFAULT,
+  CONVERSATION_MIN,
+} from '@/composables/useColumnResize'
+
+const LAPTOP = 1280
+const DESK = 1440
+const WIDE = 2560
+
+function fakeStorage(seed = {}) {
+  const map = { ...seed }
+  return {
+    getItem: (k) => (k in map ? map[k] : null),
+    setItem: (k, v) => { map[k] = String(v) },
+  }
+}
+
+describe('#2617 — the reported case', () => {
+  it('lets the rail take at least half a wide screen', () => {
+    const max = railMaxFor(WIDE, SIDEBAR_DEFAULT)
+    expect(max).toBeGreaterThanOrEqual(WIDE / 2)
+    // For the record, since "20% or something" is what was reported:
+    expect(max / WIDE).toBeGreaterThan(0.5)
+  })
+
+  it('is bigger on a bigger screen — the property a constant cannot have', () => {
+    const laptop = railMaxFor(LAPTOP, SIDEBAR_DEFAULT)
+    const desk = railMaxFor(DESK, SIDEBAR_DEFAULT)
+    const wide = railMaxFor(WIDE, SIDEBAR_DEFAULT)
+    expect(desk).toBeGreaterThan(laptop)
+    expect(wide).toBeGreaterThan(desk)
+  })
+
+  it('is exactly the space left after the sidebar and the conversation floor', () => {
+    for (const vp of [LAPTOP, DESK, WIDE, 3840]) {
+      expect(railMaxFor(vp, SIDEBAR_DEFAULT)).toBe(vp - SIDEBAR_DEFAULT - CONVERSATION_MIN)
+    }
+  })
+
+  it('shrinks as its neighbour grows, so the two cannot both claim the space', () => {
+    expect(railMaxFor(WIDE, 400)).toBe(railMaxFor(WIDE, SIDEBAR_DEFAULT) - (400 - SIDEBAR_DEFAULT))
+  })
+})
+
+describe('#2617 — narrow windows are unchanged', () => {
+  it('never offers a maximum below the column minimum', () => {
+    // A ceiling under the floor would INVERT the clamp — `min(max, max(min,px))`
+    // pins the column to the maximum and quietly breaks the floor. On a viewport
+    // with no room for three columns the auto-collapse rule applies instead.
+    expect(railMaxFor(700, SIDEBAR_DEFAULT)).toBe(RAIL_MIN)
+    expect(railMaxFor(1, 9999)).toBe(RAIL_MIN)
+    expect(sidebarMaxFor(700, RAIL_DEFAULT)).toBe(SIDEBAR_MIN)
+  })
+
+  it('an unmeasured viewport yields the minimum, never a number derived from zero', () => {
+    for (const vp of [0, null, undefined, NaN, -100, 'wide']) {
+      expect(railMaxFor(vp, SIDEBAR_DEFAULT), String(vp)).toBe(RAIL_MIN)
+    }
+  })
+
+  it('a clamped drag can never break the conversation floor', () => {
+    // The property the old constant was standing in for, now exact at every
+    // width rather than approximately right at one.
+    for (const vp of [1024, LAPTOP, DESK, 1920, WIDE]) {
+      const max = railMaxFor(vp, SIDEBAR_DEFAULT)
+      const dragged = clampRail(99999, max)
+      expect(dragged).toBe(max)
+      // At the very narrow end the rail is floored at RAIL_MIN and the
+      // auto-collapse rule — not the clamp — is what protects the floor.
+      if (max > RAIL_MIN) {
+        expect(fitsThreeColumns(vp, SIDEBAR_DEFAULT, dragged), `vp=${vp}`).toBe(true)
+      }
+    }
+  })
+
+  it('the same holds for the sidebar (AC 7 — reviewed, not left behind)', () => {
+    for (const vp of [LAPTOP, DESK, WIDE]) {
+      const max = sidebarMaxFor(vp, RAIL_DEFAULT)
+      expect(clampSidebar(99999, max)).toBe(max)
+      expect(fitsThreeColumns(vp, max, RAIL_DEFAULT), `vp=${vp}`).toBe(true)
+    }
+  })
+})
+
+describe('#2617 — a stored width survives a change of screen (AC 4)', () => {
+  it('persistence keeps the width the person asked for', () => {
+    // Not clamped to the current viewport on the way in or out. Clamping here
+    // would write the laptop's ceiling over their choice on the first commit —
+    // "silently discarded" wearing a clamp.
+    const s = fakeStorage()
+    writeStored(s, 'sam', { sidebar: SIDEBAR_DEFAULT, rail: 1400 })
+    expect(readStored(s, 'sam').rail).toBe(1400)
+  })
+
+  it('a wide-monitor width is clamped for DISPLAY on a laptop, and comes back', () => {
+    const desired = 1400   // arranged on the 2560px screen
+    const onLaptop = Math.min(desired, railMaxFor(LAPTOP, SIDEBAR_DEFAULT))
+    const backOnWide = Math.min(desired, railMaxFor(WIDE, SIDEBAR_DEFAULT))
+
+    expect(onLaptop).toBeLessThan(desired)         // clamped down, not overflowing
+    expect(onLaptop).toBe(LAPTOP - SIDEBAR_DEFAULT - CONVERSATION_MIN)
+    expect(backOnWide).toBe(desired)               // and restored, not discarded
+  })
+
+  it('still floors a hand-edited value that is far too small', () => {
+    const s = fakeStorage({
+      'trinity-workspace-columns:sam': JSON.stringify({ sidebar: 5, rail: 9 }),
+    })
+    expect(readStored(s, 'sam')).toEqual({ sidebar: SIDEBAR_MIN, rail: RAIL_MIN })
+  })
+})
+
+describe('#2617 — the composable exposes the derived ceilings', () => {
+  it('offers them where a handle can read them, and not as a stale constant', async () => {
+    const src = (await import('fs')).readFileSync(
+      (await import('url')).fileURLToPath(
+        new URL('../../src/composables/useColumnResize.js', import.meta.url),
+      ), 'utf8',
+    )
+    // `limits.rail.max` is gone rather than left holding an old number.
+    expect(src).not.toMatch(/export const RAIL_MAX/)
+    expect(src).not.toMatch(/export const SIDEBAR_MAX/)
+    expect(src).toMatch(/rail: \{ min: RAIL_MIN, default: RAIL_DEFAULT \}/)
+    // Top-level computeds, because a ref nested in a plain object is not
+    // auto-unwrapped in a template and would have rendered [object Object]
+    // into `aria-valuemax`.
+    expect(src).toMatch(/^\s*railMax,$/m)
+    expect(src).toMatch(/^\s*sidebarMax,$/m)
+  })
+
+  it('the handles read the derived value, so End and aria-valuemax follow it', async () => {
+    const shell = (await import('fs')).readFileSync(
+      (await import('url')).fileURLToPath(
+        new URL('../../src/views/Portal.vue', import.meta.url),
+      ), 'utf8',
+    )
+    expect(shell).toMatch(/:max="columns\.railMax\.value"/)
+    expect(shell).toMatch(/:max="columns\.sidebarMax\.value"/)
+    expect(shell).not.toMatch(/limits\.(rail|sidebar)\.max/)
+  })
+
+  it('the viewport is recorded even while the rail is collapsed', async () => {
+    // Otherwise reopening after a window resize would clamp against a stale
+    // ceiling — the maxima depend on a number `enforceFit` is the only writer of.
+    const src = (await import('fs')).readFileSync(
+      (await import('url')).fileURLToPath(
+        new URL('../../src/composables/useColumnResize.js', import.meta.url),
+      ), 'utf8',
+    )
+    const fn = src.slice(src.indexOf('function enforceFit'), src.indexOf('function refreshIdentity'))
+    expect(fn.indexOf('viewportWidth.value = vw')).toBeLessThan(fn.indexOf("if (!railOpen?.value) return"))
+  })
+
+  it('auto-collapse tests the EFFECTIVE width, not the desired one', async () => {
+    // Testing the desired width would collapse a rail that fits, purely because
+    // the person once arranged a wider one on a bigger screen.
+    const src = (await import('fs')).readFileSync(
+      (await import('url')).fileURLToPath(
+        new URL('../../src/composables/useColumnResize.js', import.meta.url),
+      ), 'utf8',
+    )
+    expect(src).toMatch(/fitsThreeColumns\(vw, effectiveSidebar\.value, effectiveRail\.value\)/)
+  })
+})

--- a/src/frontend/tests/unit/workspaceColumnResize.spec.js
+++ b/src/frontend/tests/unit/workspaceColumnResize.spec.js
@@ -30,10 +30,8 @@ import {
   writeStored,
   SIDEBAR_DEFAULT,
   SIDEBAR_MIN,
-  SIDEBAR_MAX,
   RAIL_DEFAULT,
   RAIL_MIN,
-  RAIL_MAX,
   RAIL_COLLAPSED,
   CONVERSATION_MIN,
   MESSAGE_MAX,
@@ -106,11 +104,17 @@ describe('ent#492 — whose layout is this', () => {
 
 describe('ent#492 — clamps', () => {
   it('bounds each column and rounds to whole pixels', () => {
+    // #2617: the ceiling is an ARGUMENT now — `SIDEBAR_MAX` / `RAIL_MAX` are
+    // gone, because a fixed pixel maximum is what stopped a 2560px screen
+    // giving its rail more than ~22%. The floors and the rounding, which is
+    // what this test is about, are unchanged.
     expect(clampSidebar(0)).toBe(SIDEBAR_MIN)
-    expect(clampSidebar(99999)).toBe(SIDEBAR_MAX)
+    expect(clampSidebar(99999, 480)).toBe(480)
     expect(clampSidebar(300.4)).toBe(300)
     expect(clampRail(0)).toBe(RAIL_MIN)
-    expect(clampRail(99999)).toBe(RAIL_MAX)
+    expect(clampRail(99999, 560)).toBe(560)
+    // With no ceiling given, a column is floored and otherwise left alone.
+    expect(clampRail(99999)).toBe(99999)
   })
 
   it('has defaults equal to the widths it replaced, so nothing moves on upgrade', () => {
@@ -142,7 +146,7 @@ describe('ent#492 — auto-collapse (AC 3)', () => {
   it('does not fit one pixel below it', () => {
     expect(fitsThreeColumns(SIDEBAR_DEFAULT + RAIL_DEFAULT + CONVERSATION_MIN - 1, SIDEBAR_DEFAULT, RAIL_DEFAULT))
       .toBe(false)
-    expect(fitsThreeColumns(900, SIDEBAR_MAX, RAIL_MAX)).toBe(false)
+    expect(fitsThreeColumns(900, 480, 560)).toBe(false)
   })
 
   it('is a decision, not an action — the caller owns the rail state', () => {
@@ -163,9 +167,13 @@ describe('ent#492 — persistence', () => {
     expect(readStored(s, 'sam')).toEqual({ sidebar: 320, rail: 420 })
   })
 
-  it('clamps on the way IN as well as out — a hand-edited value cannot break the layout', () => {
+  it('floors on the way IN as well as out — a hand-edited value cannot break the layout', () => {
+    // #2617: FLOORED here, not capped. What is stored is the width the person
+    // asked for; the viewport ceiling is applied where the number is used, so a
+    // layout arranged on a wide monitor survives a stint on a laptop. See
+    // `readStored`'s own comment and the AC-4 tests below.
     const s = fakeStorage({ 'trinity-workspace-columns:sam': JSON.stringify({ sidebar: 5, rail: 9999 }) })
-    expect(readStored(s, 'sam')).toEqual({ sidebar: SIDEBAR_MIN, rail: RAIL_MAX })
+    expect(readStored(s, 'sam')).toEqual({ sidebar: SIDEBAR_MIN, rail: 9999 })
   })
 
   it('reads corrupt, absent and unreadable storage as "no stored layout"', () => {


### PR DESCRIPTION
`RAIL_MAX = 560`, applied unconditionally, meant the **wider the display the smaller the share** a person could give the column — about 22% of a 2560px screen.

> *"I'm trying to resize the right column with canvas, but it does not go bigger than like 20% or something. I should be able to make it whatever I want, say half the screen width."*

That is the opposite of what a resize handle is for, and it contradicted the file's own stated intent — *"deliberately generous — this is a person arranging their own screen, not a layout that needs defending from them"* — which an absolute pixel number cannot express at more than one width.

## The bound that replaces it was already in the file

`CONVERSATION_MIN` is the readable floor `fitsThreeColumns` already refuses to break. So a column may take everything left after its neighbour and that floor:

```
railMaxFor(viewport, sidebar) = viewport − sidebar − CONVERSATION_MIN
```

On 2560 with the default sidebar that is ~70% of the screen; on a laptop it is exactly what the auto-collapse rule already permitted. **One rule at both ends**, rather than a constant that is generous at one width and restrictive at every other.

## Three details that are load-bearing

- **Floored at the column's own minimum.** A ceiling *below* the floor inverts `Math.min(max, Math.max(min, px))` — it pins the column to the **maximum** and quietly breaks the floor the minimum exists to hold. On a viewport with no room for three columns the auto-collapse rule applies, not a negative ceiling.
- **Desired width and effective width are two numbers (AC 4).** What is stored and dragged is what the person asked for; what the grid renders is `min(desired, derived max)`. So a layout arranged on a 2560px monitor is clamped down for display on a laptop and **comes back intact**. Clamping at the persistence boundary instead would have written the laptop's ceiling over their choice on the first `commit()` — "silently discarded" wearing a clamp, which is the failure mode the AC names.
- **`enforceFit` tests the EFFECTIVE widths.** Testing the desired one would collapse a rail that *fits*, purely because a wider one was once arranged on a bigger screen. And since the drag is now bounded by the same floor `fitsThreeColumns` asks about, a drag can no longer break the fit at all — what remains for auto-collapse is exactly the case it was written for: a window too narrow for three columns at their minima.

## Acceptance criteria

- [x] The rail drags to at least half the viewport on a wide display — the operator's 2560px case reaches ~70%, asserted.
- [x] The maximum is derived from the viewport; the conversation's floor is the one rule that stops a drag. No fractional-viewport fallback was needed, because the derivation already is one.
- [x] Narrow windows unchanged — the conversation never drops below its floor, and `fitsThreeColumns` → `enforceFit` still fires before it is squeezed.
- [x] A stored width larger than the current maximum is clamped for display and restored when there is room — neither discarded nor overflowing.
- [x] Keyboard parity: `railMax` / `sidebarMax` are what the handles receive, so `End` and `aria-valuemax` follow the derived value and update on window resize.
- [x] Narrowing the rail still widens the message column up to `MESSAGE_MAX`, untouched.
- [x] `SIDEBAR_MAX` reviewed and given the same treatment (AC 7) — nobody had hit it, but leaving one derived and one fixed would leave the next reader guessing which rule this file follows.
- [x] Vitest coverage at 1280 / 1440 / 2560 including the re-clamp-on-load case; the `fitsThreeColumns` tests stay green.

## A trap worth naming for review

The ceilings are exposed as **top-level computeds**, not folded back into `limits`. A ref nested inside a plain object is **not** auto-unwrapped in a template, so `:max="columns.limits.rail.max"` would have rendered `[object Object]` into `aria-valuemax` — silently, since nothing type-checks an ARIA attribute. `limits` now carries no `max` at all rather than a stale number a caller could still read and believe.

## Verification

- New `workspaceColumnMaxFromViewport.spec.js` — **15 passed**: the reported case, the exact derivation at four widths, monotonicity in viewport width, the neighbour trade-off, the inverted-clamp guard, an unmeasured viewport (`0`/`null`/`NaN`/a string), that a clamped drag can never break the conversation floor at any width, the sidebar's parity, and the AC-4 round trip (arranged at 2560 → clamped on a laptop → restored at 2560).
- `workspaceColumnResize.spec.js` — two assertions rewritten, not deleted: the ceiling is an argument now, and persistence **floors** rather than caps. Both rewrites say why in place.
- Full frontend suite **113 files / 2530 tests**; both ratchets green; `vite build` clean.
- Grepped for stragglers: no reference to `RAIL_MAX`, `SIDEBAR_MAX` or `limits.*.max` survives outside the comments that explain their removal.

## What I could not check

No browser here, so the *feel* of dragging to 70% of a 2560px screen is unverified — the arithmetic, the clamp behaviour and the wiring are. The `aria-valuemax` trap above is the reason I would still want one pass with a real handle in hand.

Fixes #2617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bd71qsYbFodvofba8P69eP