### PR TITLE
feat(workspace): Trinity's logo and "Trinity Workspace" in the top left (ent#556)

### DIFF
--- a/src/frontend/src/components/portal/PortalBrand.vue
+++ b/src/frontend/src/components/portal/PortalBrand.vue
@@ -1,0 +1,58 @@
+<template>
+  <!-- ent#556: the Workspace's brand corner — Trinity's mark and the product's
+       name, in the two places that must agree (the signed-in shell and the
+       sign-in screen). ONE component rather than two copies of the markup:
+       "both surfaces carry the same mark and wording" is an acceptance
+       criterion, and two copies is how that stops being true.
+
+       `is` picks the element: a `router-link` where there is somewhere true to
+       go, a plain `div` where there is not (signed out, the mark has no
+       destination that would mean anything). Never a dead affordance, and
+       never a platform route — see `WORKSPACE_ROOT`. -->
+  <component
+    :is="to ? 'router-link' : 'div'"
+    :to="to || undefined"
+    class="flex items-center gap-2 min-w-0"
+    :class="to ? 'hover:opacity-80 transition-opacity' : null"
+    :aria-label="WORKSPACE_BRAND_NAME"
+  >
+    <!-- The light/dark swap follows `components/NavBar.vue` rather than
+         inventing a second pattern — a dark mark on a dark ground is the one
+         failure this must not have. Both images are decorative: the accessible
+         name is on the element above, so a screen reader says the product once,
+         and says it whether or not the wordmark is visible at this width. -->
+    <img
+      src="../../assets/trinity-logo.svg"
+      alt=""
+      aria-hidden="true"
+      :class="[markSize, 'shrink-0 dark:hidden']"
+    />
+    <img
+      src="../../assets/trinity-logo-white.svg"
+      alt=""
+      aria-hidden="true"
+      :class="[markSize, 'shrink-0 hidden dark:block']"
+    />
+    <!-- `truncate` + `min-w-0` are load-bearing, not tidiness: the sidebar is
+         resizable down to `SIDEBAR_MIN` (200px, ent#492) and this row also
+         carries the ask and unread badges. Without them the name pushes the
+         badges out of the band. -->
+    <span :class="[textSize, 'font-semibold truncate min-w-0']">{{ WORKSPACE_BRAND_NAME }}</span>
+  </component>
+</template>
+
+<script setup>
+import { WORKSPACE_BRAND_NAME } from './portalBrand'
+
+defineProps({
+  /** Route to navigate to, or null for an inert mark (the signed-out screen). */
+  to: { type: [String, Object], default: null },
+  /**
+   * The mark's box. Defaults to the size the generic icon it replaces used, so
+   * the `h-14` header band ent#547 is shortening does not grow.
+   */
+  markSize: { type: String, default: 'h-6 w-6' },
+  /** Type scale for the wordmark; the shell's default, larger on sign-in. */
+  textSize: { type: String, default: '' },
+})
+</script>

--- a/src/frontend/src/components/portal/PortalSidebar.vue
+++ b/src/frontend/src/components/portal/PortalSidebar.vue
@@ -320,7 +320,6 @@ import { computed, ref } from 'vue'
 import PortalAvatar from './PortalAvatar.vue'
 import ChatRow from './PortalChatRow.vue'
 import PortalBrand from './PortalBrand.vue'
-import { WORKSPACE_ROOT } from './portalBrand'
 import BaseBadge from '@/components/base/BaseBadge.vue'
 import { useClientPortalStore } from '@/stores/clientPortal'
 import {
@@ -331,6 +330,7 @@ import {
   signOutLabelFor,
   searchAgents, sidebarSearchState, searchEmptyLines,
   agentResultsLabel, agentToggleLabel, showAgentToggle, SEARCH_PLACEHOLDER,
+  WORKSPACE_ROOT,
 } from './portalUtils'
 
 const props = defineProps({

--- a/src/frontend/src/components/portal/PortalSidebar.vue
+++ b/src/frontend/src/components/portal/PortalSidebar.vue
@@ -7,8 +7,11 @@
          the agents block now occupies the top of the scroll region and would
          otherwise scroll a fleet-wide signal out of view. -->
     <div class="shrink-0 flex items-center gap-2 px-4 h-14 border-b border-gray-200 dark:border-gray-800">
-      <svg class="w-6 h-6 text-action-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" /></svg>
-      <span class="font-semibold">Workspace</span>
+      <!-- ent#556: Trinity's mark and the product's name, replacing a
+           hand-drawn outline icon and the bare word "Workspace". Linked to the
+           Workspace root — true for both principals, and the only destination a
+           client session can actually open. -->
+      <PortalBrand :to="WORKSPACE_ROOT" />
       <!-- ent#364: an ASK is a distinct fact from an unread reply — one is waiting
            on you to decide, the other on you to read — so it gets its own badge
            rather than being summed into that one. Before the unread count,
@@ -316,6 +319,8 @@
 import { computed, ref } from 'vue'
 import PortalAvatar from './PortalAvatar.vue'
 import ChatRow from './PortalChatRow.vue'
+import PortalBrand from './PortalBrand.vue'
+import { WORKSPACE_ROOT } from './portalBrand'
 import BaseBadge from '@/components/base/BaseBadge.vue'
 import { useClientPortalStore } from '@/stores/clientPortal'
 import {

--- a/src/frontend/src/components/portal/portalBrand.js
+++ b/src/frontend/src/components/portal/portalBrand.js
@@ -19,13 +19,3 @@
  * call; one constant with one reader is what keeps that call cheap.
  */
 export const WORKSPACE_BRAND_NAME = 'Trinity Workspace'
-
-/**
- * Where the mark goes when it is a link.
- *
- * The Workspace root, and nowhere else. A client session holds no `users` row,
- * so a platform route would be a door that 404s or bounces to `/login` for
- * exactly the audience this surface exists for — a dead affordance is one of
- * the two failures this must not have (the other being an unlabelled one).
- */
-export const WORKSPACE_ROOT = '/workspace'

--- a/src/frontend/src/components/portal/portalBrand.js
+++ b/src/frontend/src/components/portal/portalBrand.js
@@ -1,0 +1,31 @@
+/**
+ * The Workspace's brand facts (ent#556).
+ *
+ * A plain module, not a constant inside the SFC, for the reason the rest of
+ * this directory splits the same way: `vitest` runs `environment: 'node'` with
+ * no component-mount harness, so anything a test must read has to be importable
+ * without mounting.
+ */
+
+/**
+ * What the Workspace calls itself, in both places that must agree.
+ *
+ * Deliberately the PRODUCT name and not an instance name. The platform does
+ * resolve a per-instance label (`services/instance_identity.py`,
+ * `TRINITY_INSTANCE_NAME`), and a company running Trinity could plausibly want
+ * its own name in this corner — but this surface's audience is the operator's
+ * own organisation (ent#78, ruled 2026-09-06) and naming the product is the
+ * point of the ask. Instance naming and white-labelling are a separate, later
+ * call; one constant with one reader is what keeps that call cheap.
+ */
+export const WORKSPACE_BRAND_NAME = 'Trinity Workspace'
+
+/**
+ * Where the mark goes when it is a link.
+ *
+ * The Workspace root, and nowhere else. A client session holds no `users` row,
+ * so a platform route would be a door that 404s or bounces to `/login` for
+ * exactly the audience this surface exists for — a dead affordance is one of
+ * the two failures this must not have (the other being an unlabelled one).
+ */
+export const WORKSPACE_ROOT = '/workspace'

--- a/src/frontend/src/components/portal/portalUtils.js
+++ b/src/frontend/src/components/portal/portalUtils.js
@@ -630,6 +630,12 @@ export function collapseSelection(selected, { multi = false } = {}) {
 // the same predicate rather than in a second one somebody has to remember.
 export const STAGE_QUERY_KEYS = ['agent', 'new', 'voice']
 
+// The Workspace root. Two consumers: the stage guard below, and the brand
+// mark's link target (ent#556, `PortalBrand`). It is the only route the mark
+// may point at — a client session holds no `users` row, so a platform route
+// would be a door that 404s or bounces to `/login` for exactly the audience
+// this surface exists for, and a dead affordance is one of the two failures
+// the brand corner must not have (the other being an unlabelled one).
 export const WORKSPACE_ROOT = '/workspace'
 
 export function shouldEscapeStage(path, query) {

--- a/src/frontend/src/router/index.js
+++ b/src/frontend/src/router/index.js
@@ -265,7 +265,16 @@ export const routes = [
     path: '/workspace/a/:agentName',
     name: 'WorkspaceAgent',
     component: () => import('../views/Portal.vue'),
-    meta: { title: 'Workspace', hideHelpWidget: true }
+    // ent#556: the one Workspace route whose subject the ROUTE knows, so it is
+    // the one that can name it. Keeps the surface in the title — a bare agent
+    // name would lose "Workspace" — and reuses `agentTabTitle`, so an operator
+    // (warm agents store) sees the display name and a client session, which
+    // never populates that store, falls back to the slug. Threads and rooms
+    // cannot do this: their subject lives in component state, not the route.
+    meta: {
+      title: (to) => `Workspace · ${agentTabTitle(to.params.agentName)}`,
+      hideHelpWidget: true,
+    }
   },
   // ent#357 legacy paths. Function form so query AND hash survive the hop —
   // these URLs were handed to real clients by email, and a client landing on a

--- a/src/frontend/src/views/Portal.vue
+++ b/src/frontend/src/views/Portal.vue
@@ -13,9 +13,13 @@
     <!-- ============================ SIGN-IN ============================ -->
     <div v-else-if="!store.isClientSignedIn" class="flex-1 flex items-center justify-center px-4">
       <div class="w-full max-w-sm">
-        <div class="flex items-center gap-2 mb-6">
-          <svg class="w-7 h-7 text-action-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" /></svg>
-          <span class="font-semibold text-lg">Workspace</span>
+        <!-- ent#556: the same mark and wording as the signed-in shell, from the
+             same component. Deliberately INERT here: the reader is signed out
+             and already at the Workspace root, so a link would go nowhere they
+             are not — and the one destination that would mean something is a
+             platform route a client session cannot open. -->
+        <div class="mb-6">
+          <PortalBrand mark-size="h-7 w-7" text-size="text-lg" />
         </div>
 
         <!-- #2261 — the store has set `sessionExpired` since ent#375 and nothing
@@ -569,6 +573,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useClientPortalStore, MULTI_AGENT_UNAVAILABLE, PLATFORM_LOGIN_ROUTE } from '@/stores/clientPortal'
 import { useAuthStore } from '@/stores/auth'
 import PortalSidebar from '@/components/portal/PortalSidebar.vue'
+import PortalBrand from '@/components/portal/PortalBrand.vue'
 import PortalConversation from '@/components/portal/PortalConversation.vue'
 import PortalBriefing from '@/components/portal/PortalBriefing.vue'
 import PortalLoops from '@/components/portal/PortalLoops.vue'

--- a/src/frontend/tests/unit/workspaceBranding.spec.js
+++ b/src/frontend/tests/unit/workspaceBranding.spec.js
@@ -18,7 +18,10 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { stripComments } from './helpers/stripComments'
-import { WORKSPACE_BRAND_NAME, WORKSPACE_ROOT } from '@/components/portal/portalBrand'
+import { WORKSPACE_BRAND_NAME } from '@/components/portal/portalBrand'
+// The route lives in `portalUtils`, which owns it for the stage guard and the
+// sign-out target; the mark is a third consumer, not a second definition.
+import { WORKSPACE_ROOT } from '@/components/portal/portalUtils'
 
 const read = (rel) => stripComments(readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8'))
 

--- a/src/frontend/tests/unit/workspaceBranding.spec.js
+++ b/src/frontend/tests/unit/workspaceBranding.spec.js
@@ -1,0 +1,149 @@
+/**
+ * ent#556 — the Workspace says which product it is.
+ *
+ * The top left was a hand-drawn outline `<svg>` and the bare word "Workspace",
+ * in two places that had to agree and had no shared source. The real marks
+ * (`assets/trinity-logo.svg` / `-white.svg`) already shipped and were already
+ * used by `NavBar` and `PublicChat`; the Workspace simply never adopted them.
+ *
+ * A source-guard spec, this project's pattern for wiring only source can answer
+ * — `vitest` runs `environment: 'node'` with no component-mount harness. The one
+ * genuinely decidable fact (the name, and where the mark may point) lives in a
+ * plain module and is asserted as a value, not as a string in markup.
+ *
+ * Comments are stripped before every scan: a comment explaining what NOT to
+ * write necessarily contains the offending string.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { stripComments } from './helpers/stripComments'
+import { WORKSPACE_BRAND_NAME, WORKSPACE_ROOT } from '@/components/portal/portalBrand'
+
+const read = (rel) => stripComments(readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8'))
+
+const BRAND = read('../../src/components/portal/PortalBrand.vue')
+const SIDEBAR = read('../../src/components/portal/PortalSidebar.vue')
+const PORTAL = read('../../src/views/Portal.vue')
+const NAVBAR = read('../../src/components/NavBar.vue')
+const ROUTER = read('../../src/router/index.js')
+
+// The generic outline icon the brand corner used to draw. It is still a
+// legitimate EMPTY-STATE illustration elsewhere in `Portal.vue` (the stage
+// zones), so the guard is scoped to the brand blocks rather than the file.
+const GENERIC_ICON_PATH = 'M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z'
+
+describe('ent#556 the name is a value, not a string in two templates', () => {
+  it('names the product', () => {
+    expect(WORKSPACE_BRAND_NAME).toBe('Trinity Workspace')
+  })
+
+  it('points the mark at the Workspace root and nowhere else', () => {
+    // A client session holds no `users` row, so a platform route would be a
+    // door that bounces exactly the audience this surface exists for.
+    expect(WORKSPACE_ROOT).toBe('/workspace')
+  })
+
+  it('renders the name from the module rather than re-typing it', () => {
+    expect(BRAND).toContain('WORKSPACE_BRAND_NAME')
+    // Not a literal in the template — that is how the two surfaces drifted.
+    expect(BRAND).not.toContain('>Trinity Workspace<')
+  })
+})
+
+describe('ent#556 both surfaces carry the same mark, from one component', () => {
+  it('the signed-in shell renders it', () => {
+    expect(SIDEBAR).toContain('<PortalBrand')
+    expect(SIDEBAR).toContain("import PortalBrand from './PortalBrand.vue'")
+  })
+
+  it('the sign-in screen renders it', () => {
+    expect(PORTAL).toContain('<PortalBrand')
+    expect(PORTAL).toContain("import PortalBrand from '@/components/portal/PortalBrand.vue'")
+  })
+
+  it('neither brand corner draws the old generic icon any more', () => {
+    expect(SIDEBAR).not.toContain(GENERIC_ICON_PATH)
+    // `Portal.vue` legitimately keeps it in the stage empty-states; what must
+    // be gone is the brand block, identified by the wording it carried.
+    expect(PORTAL).not.toContain('<span class="font-semibold text-lg">Workspace</span>')
+  })
+
+  it('no bare "Workspace" wordmark is left in either brand block', () => {
+    expect(SIDEBAR).not.toContain('<span class="font-semibold">Workspace</span>')
+  })
+})
+
+describe('ent#556 dark mode is correct', () => {
+  it('uses both marks with the light/dark swap', () => {
+    expect(BRAND).toContain('trinity-logo.svg')
+    expect(BRAND).toContain('trinity-logo-white.svg')
+  })
+
+  it('follows NavBar rather than inventing a second pattern', () => {
+    // The standard mark hides in dark; the white mark shows only in dark. A
+    // dark logo on a dark ground is the one failure this must not have.
+    expect(BRAND).toMatch(/trinity-logo\.svg[\s\S]{0,240}?dark:hidden/)
+    expect(BRAND).toMatch(/trinity-logo-white\.svg[\s\S]{0,240}?hidden dark:block/)
+    expect(NAVBAR).toMatch(/trinity-logo\.svg[\s\S]{0,240}?dark:hidden/)
+    expect(NAVBAR).toMatch(/trinity-logo-white\.svg[\s\S]{0,240}?hidden dark:block/)
+  })
+})
+
+describe('ent#556 the mark is neither dead nor unlabelled', () => {
+  it('is a link only when it has somewhere to go', () => {
+    // `router-link` when `to` is set, a plain element when it is not — the
+    // sign-in screen has no destination that would mean anything.
+    expect(BRAND).toContain("to ? 'router-link' : 'div'")
+  })
+
+  it('carries an accessible name whether or not the wordmark is visible', () => {
+    // The images are decorative — the name is on the wrapper, so a screen
+    // reader says the product ONCE, and still says it if the wordmark is
+    // truncated away at a narrow sidebar width.
+    expect(BRAND).toContain(':aria-label="WORKSPACE_BRAND_NAME"')
+    expect(BRAND).toContain('aria-hidden="true"')
+    expect(BRAND).not.toContain('alt="Trinity"')
+  })
+
+  it('the signed-in shell links to the Workspace root, not a platform route', () => {
+    expect(SIDEBAR).toContain(':to="WORKSPACE_ROOT"')
+  })
+
+  it('the sign-in screen renders it inert', () => {
+    // No `:to` on that instance: signed out, the reader is already at the root.
+    expect(PORTAL).toMatch(/<PortalBrand(?![^>]*:to=)[^>]*\/>/)
+  })
+})
+
+describe('ent#556 it fits the header it lives in', () => {
+  it('keeps the mark at the size the icon it replaces used', () => {
+    // ent#547 is SHORTENING this band; the brand must not grow it.
+    expect(BRAND).toContain("markSize: { type: String, default: 'h-6 w-6' }")
+  })
+
+  it('truncates rather than pushing the badges out of the band', () => {
+    // The sidebar resizes down to SIDEBAR_MIN (200px, ent#492) and this row
+    // also carries the ask and unread badges.
+    expect(BRAND).toContain('truncate min-w-0')
+    expect(BRAND).toContain("class=\"flex items-center gap-2 min-w-0\"")
+  })
+})
+
+describe('ent#556 the tab title identifies the product and the subject', () => {
+  it('every Workspace route still carries a title', () => {
+    // The router renders `Trinity — <label>`, so a Workspace tab reads
+    // "Trinity — Workspace". The platform has ONE title format (#1418) and
+    // this surface does not get a second one.
+    const workspaceTitles = ROUTER.match(/title: 'Workspace'/g) || []
+    expect(workspaceTitles.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('names the agent on the one route whose subject the route knows', () => {
+    expect(ROUTER).toContain('`Workspace · ${agentTabTitle(to.params.agentName)}`')
+  })
+
+  it('keeps the agent-scoped platform titles it must not have broken', () => {
+    expect(ROUTER).toContain('title: (to) => agentTabTitle(to.params.name)')
+  })
+})


### PR DESCRIPTION
The Workspace's brand corner was a hand-drawn outline `<svg>` and the bare word "Workspace", in two places that had to agree and had no shared source: the signed-in shell (`PortalSidebar.vue`) and the sign-in screen (`views/Portal.vue`). The real marks already shipped and were already used by `NavBar` and `PublicChat` — the Workspace simply never adopted them.

| | before | after |
|---|---|---|
| shell + sign-in | outline chat-bubble icon · "Workspace" | Trinity mark · **Trinity Workspace** |

Both surfaces now render **one** component, `PortalBrand.vue`. "Both surfaces carry the same mark and wording" is an AC, and two copies of the markup is exactly how that stops being true.

## The naming decision, stated

The name is a value in `portalBrand.js`, and it is deliberately the **product** name. The platform does resolve a per-instance label (`services/instance_identity.py`, `TRINITY_INSTANCE_NAME`), and a company running Trinity could plausibly want its own name in that corner — but this surface's audience is the operator's own organisation (ent#78, ruled 2026-09-06) and naming the product is the point of the ask. Instance naming and white-labelling stay a separate, later call; one constant with one reader is what keeps that call cheap.

## Load-bearing, not tidiness

- **The light/dark swap follows `NavBar`** rather than inventing a second pattern — a dark mark on a dark ground is the one failure this must not have.
- **Neither dead nor mislinked.** The shell links to the Workspace root; the sign-in screen renders the mark **inert**, because a client session holds no `users` row and the reader is already at the root. `:is` picks `router-link` or `div`.
- **The accessible name is on the wrapper; the images are decorative.** A screen reader says the product once — and still says it when the wordmark truncates at a narrow sidebar. This is why `alt=""` rather than `alt="Trinity"`: with the name beside them, alt text would double-read. The AC asked alt to name the product; putting the name on the wrapper delivers that in both the wide and truncated states, which alt alone cannot.
- **`truncate min-w-0` + `shrink-0`.** The sidebar resizes to `SIDEBAR_MIN` (200px, ent#492) and this row also carries the ask and unread badges; without them the name pushes the badges out of the band.
- **The mark keeps the 24px box the icon it replaces used**, so the `h-14` band ent#547 is shortening does not grow. Measured at 56px in the browser.

## Tab titles — what I did and did not change

The platform renders `Trinity — <label>` (#1418), so a Workspace tab already reads **"Trinity — Workspace"**. I kept that single format rather than giving one surface a second one; a bespoke absolute title here would break the convention and its e2e for a difference of one em dash. **Flagging it rather than deciding silently** — if you want the tab to read literally `Trinity Workspace`, that is a one-line change to the title guard and I'll make it.

What is added is identifiability where the **route** knows its subject: `/workspace/a/:agentName` now titles `Workspace · <agent>` through the existing `agentTabTitle`, so an operator sees the display name and a client falls back to the slug. Threads and rooms cannot do this — their subject is component state, not a route param.

The generic icon **stays** where it is still a legitimate empty-state illustration (the `Portal.vue` stage zones). It was a brand mark only in the two blocks this replaces, and the guard is scoped accordingly.

## Acceptance criteria

- [x] logo + "Trinity Workspace", existing assets, platform-navigation weight
- [x] dark mode correct — white on dark, standard on light, `NavBar` pattern
- [x] both surfaces agree; no generic icon or bare "Workspace" left in either brand block
- [x] not a dead affordance — linked to the Workspace root in the shell, inert and labelled on sign-in, never a platform route
- [x] tab title names the product (see the note above) and now names the agent on the agent route; the agent-scoped platform titles it must not break are pinned
- [x] name given to assistive tech; collapses at narrow rail widths; header band unchanged
- [x] layout holds at 1280 and 1920, light and dark, signed in and signed out

## Verification

```
2534 passed (113 files)   npm run test:unit — 18 new source-guard cases
10 passed                 real Chromium: both surfaces × {1280,1920} × {light,dark}
```

The browser pass asserts exactly one mark visible per theme and that it is the right one, the 56px band height, the badges staying inside a 200px sidebar, and the agent tab title. Mutation-checked: a dark-on-dark swap and a platform-route link on the signed-out mark each turn the suite red.

Run locally against a `vite preview` build with the API mocked (no backend container up on this box); the rig was discarded. Screenshots of the brand corner in both themes are in the session.

Fixes abilityai/trinity-enterprise#556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bd71qsYbFodvofba8P69eP
