### PR TITLE
fix(ui): stop Files-tab preview blowing past the panel clip (#2666)

### DIFF
--- a/src/frontend/src/components/FilesPanel.vue
+++ b/src/frontend/src/components/FilesPanel.vue
@@ -91,7 +91,12 @@
       </div>
 
       <!-- Right Panel: Preview -->
-      <div class="flex-1 flex flex-col bg-gray-50 dark:bg-gray-900">
+      <!-- #2666: `min-w-0` is load-bearing. A flex item's automatic minimum
+           size is its content's min-content width, so one unbreakable token in
+           a previewed file made this column refuse to shrink; the root clips
+           (`overflow-hidden`) and nothing scrolls horizontally, so the overflow
+           was unreachable — measured 3048px of content in a 1280px clip. -->
+      <div class="flex-1 min-w-0 flex flex-col bg-gray-50 dark:bg-gray-900">
         <!-- No File Selected -->
         <div v-if="!selectedFile" class="flex-1 flex items-center justify-center">
           <div class="text-center">

--- a/src/frontend/src/components/file-manager/FilePreview.vue
+++ b/src/frontend/src/components/file-manager/FilePreview.vue
@@ -100,9 +100,14 @@
           spellcheck="false"
         ></textarea>
         <!-- View Mode: Pre/Code -->
+        <!-- #2666: `break-words` beside `whitespace-pre-wrap`, which wraps at
+             ordinary break opportunities only. Wrap rather than horizontal
+             scroll, deliberately: it matches `PortalFilePreview.vue`, and a
+             scrollbar here would sit at the bottom of a `<pre>` that can be
+             80 KB tall — below the fold, so unreachable. -->
         <pre
           v-else
-          class="p-4 text-sm font-mono bg-gray-900 text-gray-100 rounded-lg m-2 overflow-auto whitespace-pre-wrap"
+          class="p-4 text-sm font-mono bg-gray-900 text-gray-100 rounded-lg m-2 overflow-auto whitespace-pre-wrap break-words"
         ><code>{{ textContent }}</code></pre>
       </div>
 

--- a/src/frontend/tests/unit/filesPanelPreviewClip.spec.js
+++ b/src/frontend/tests/unit/filesPanelPreviewClip.spec.js
@@ -1,0 +1,84 @@
+/**
+ * #2666 — the Files-tab preview must not grow past the panel's clip.
+ *
+ * The panel root is `flex h-[calc(100vh-220px)] overflow-hidden` and nothing in
+ * the chain scrolls horizontally. The preview column beside the file tree was a
+ * flex item at the default `min-width: auto`, i.e. it could not shrink below the
+ * MIN-CONTENT width of everything inside it — and the `<pre>` that renders file
+ * text had no break rule, so one unbreakable token (a path, a URL, a base64
+ * blob, a run of `===`) became that min-content width. The pane grew to fit the
+ * token, the root clipped it, and there was no scrollbar anywhere to reach it.
+ * Because the `<pre>` is `whitespace-pre-wrap`, ORDINARY lines then wrapped at
+ * the blown-out width too, so the whole preview was cut off, not just the token.
+ *
+ * Both classes are load-bearing, and each fixes a different half — measured in a
+ * real browser (Chromium, 1280px viewport, a file whose content holds one
+ * 320-char unbreakable token), reading `scrollWidth/clientWidth`:
+ *
+ *   neither          root 3048/1280   pane 2768   pre 2720   sidebar 280px
+ *   break-words only root 3048/1280   pane 2768   pre 2720   sidebar 280px
+ *   min-w-0 only     root 1280/1280   pane  960   pre 2720/912 (scrollbar)
+ *   both             root 1280/1280   pane  960   pre  912/912  sidebar 320px
+ *
+ * `break-words` alone changes nothing: with `min-width: auto` the pane still
+ * sizes to min-content, which a break-word rule does not reduce. `min-w-0` alone
+ * satisfies the "pane stops growing" half but leaves the token overflowing into
+ * the `<pre>`'s own `overflow-auto` — a horizontal scrollbar at the bottom of an
+ * element that can be 80 KB tall, i.e. below the fold and unreachable for
+ * exactly the files that need it. Only the pair leaves every line readable.
+ *
+ * vitest here runs `environment: 'node'` with no component-mount harness, and
+ * even a DOM harness computes no layout — so the browser measurement above
+ * cannot live in CI. This is the source-structure guard for it, the same shape
+ * as `agentDetailDeepLink.spec.js` and the Python AST guards.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+const read = (rel) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8')
+
+const filesPanel = read('../../src/components/FilesPanel.vue')
+const filePreview = read('../../src/components/file-manager/FilePreview.vue')
+const portalPreview = read('../../src/components/portal/PortalFilePreview.vue')
+
+/** Classes of the element whose class attribute contains every given token. */
+function classesOfElementWith(source, ...tokens) {
+  const matches = [...source.matchAll(/class="([^"]*)"/g)]
+    .map((m) => m[1])
+    .filter((cls) => tokens.every((t) => cls.split(/\s+/).includes(t)))
+  expect(matches, `no element found with classes ${tokens.join(' + ')}`).toHaveLength(1)
+  return matches[0].split(/\s+/)
+}
+
+/** The break rules that make a long unbreakable token wrap rather than overflow. */
+const BREAK_RULES = ['break-words', 'break-all', 'overflow-wrap-anywhere']
+
+describe('#2666 Files-tab preview stays inside the panel clip', () => {
+  it('the preview column can shrink below its min-content width', () => {
+    // The right-hand pane in the two-panel layout. Identified by its own
+    // background, which nothing else in the file carries.
+    const cls = classesOfElementWith(filesPanel, 'flex-1', 'bg-gray-50', 'dark:bg-gray-900')
+    expect(cls).toContain('min-w-0')
+  })
+
+  it('the panel root still clips, which is why min-w-0 is required', () => {
+    // If this ever stops being true — because the root gained a horizontal
+    // scroll instead — the reasoning above needs re-deriving, not just the class.
+    const cls = classesOfElementWith(filesPanel, 'h-[calc(100vh-220px)]')
+    expect(cls).toContain('overflow-hidden')
+  })
+
+  it('the text preview breaks an unbreakable token instead of overflowing', () => {
+    const cls = classesOfElementWith(filePreview, 'whitespace-pre-wrap')
+    expect(BREAK_RULES.some((rule) => cls.includes(rule))).toBe(true)
+  })
+
+  it('matches the PortalFilePreview precedent it was fixed against', () => {
+    // The Workspace preview renders text the same way and has never shown this;
+    // #2666 is the agent-side panel catching up. If that file changes its mind
+    // about wrap-vs-scroll, the two surfaces should be reconciled deliberately.
+    const cls = classesOfElementWith(portalPreview, 'whitespace-pre-wrap')
+    expect(BREAK_RULES.some((rule) => cls.includes(rule))).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes the Files-tab preview clip reported in #2666.

## The bug

Previewing a text file containing one **unbreakable token** — a long path, a URL, a base64 blob, a run of `===` — grew the whole preview pane far past the visible area. The panel root is `flex h-[calc(100vh-220px)] overflow-hidden` and nothing in the chain scrolls horizontally, so the overflow was **unreachable**: every line cut off at the right edge, no scrollbar to drag. And because the `<pre>` is `whitespace-pre-wrap`, ordinary prose then wrapped at the *blown-out* width too — so the whole preview was clipped, not just the token.

## The fix — two classes, each fixing a different half

- **`FilesPanel.vue`** — `min-w-0` on the preview column. As a flex item at the default `min-width: auto` it could not shrink below the **min-content** width of its contents, which the token defined.
- **`FilePreview.vue`** — `break-words` on the `<pre>`.

**Wrap, not horizontal scroll — deliberately.** The issue left this open. Wrap wins on three grounds: it matches the in-repo precedent `PortalFilePreview.vue` (same `whitespace-pre-wrap break-words` inside a `min-w-0` chain, and it has never shown this); it is what the design-system contract asks for (bounded viewport, unbounded data); and a horizontal scrollbar here would sit at the bottom of a `<pre>` that can be 80 KB tall — below the fold, so unreachable for exactly the files that need it.

## Measured, not asserted

Chromium at a 1280px viewport, real components mounted with a stubbed store, previewing a file whose content holds one 320-char unbreakable token. Reading `scrollWidth/clientWidth`:

| state | panel root | pane | `<pre>` | sidebar |
|---|---|---|---|---|
| neither class | **3048 / 1280** | 2768 | 2720 | **280px** |
| `break-words` only | **3048 / 1280** | 2768 | 2720 | **280px** |
| `min-w-0` only | 1280 / 1280 | 960 | **2720 / 912** | 320px |
| **both (this PR)** | **1280 / 1280** | 960 | **912 / 912** | **320px** |

`documentElement` was 1280/1280 throughout — i.e. no page scrollbar either, matching the report.

Each class is proven load-bearing by that table. `break-words` **alone changes nothing**: with `min-width: auto` the pane still sizes to min-content, which a break-word rule does not reduce. `min-w-0` **alone** stops the pane growing but leaves the token overflowing into the `<pre>`'s own `overflow-auto` — the below-the-fold scrollbar the fix exists to avoid.

Two notes on the numbers:
- The sidebar shrinking **320px → 280px** in the broken states (it bottoms out on its own `min-w-[280px]`) is the layout-stability half of the report — AC #3.
- The issue measured `overflow-wrap: anywhere`; `break-words` (`overflow-wrap: break-word`) is enough here and matches the precedent. The two differ only in *min-content* contribution, and with `min-w-0` present the pane's width is no longer content-derived — confirmed by the 912/912 row.

## Acceptance criteria

- [x] 300+ char unbreakable token leaves panel root `scrollWidth == clientWidth` — **1280 / 1280**
- [x] All content reachable — it **wraps** inside the pane (`pre` 912/912)
- [x] Sidebar keeps its width, layout stable — **320px**, unchanged
- [x] Edit mode (`<textarea>`) — no pane blow-out. It never blew out (a textarea's width is not content-derived, and Chrome's UA sheet already gives it `overflow-wrap: break-word`); measured at root 1280/1280, ta 912/912 to confirm rather than assume.
- [x] Design-system contract: bounded viewport for unbounded data
- [x] `npm run test:unit` green — **117 files / 2592 tests**; no raw-color or loading-gate baseline change (the diff adds no colour classes; `scan-raw-colors.mjs` exits 0, and `loadingGateRatchet.spec.js` is in the passing run)

## Regression guard

vitest here runs `environment: 'node'` with no mount harness — and even a DOM harness computes no layout — so the browser measurement above cannot live in CI. `tests/unit/filesPanelPreviewClip.spec.js` is the source-structure guard for it (the `agentDetailDeepLink.spec.js` shape). It pins:

1. `min-w-0` on the preview column;
2. that the panel root **still clips** — the premise that makes `min-w-0` necessary, so a future change to a scrolling root forces the reasoning to be re-derived rather than the class silently kept;
3. a break rule on the `<pre>`;
4. the same break rule on `PortalFilePreview.vue`, so the two surfaces cannot silently disagree about wrap-vs-scroll.

Each assertion was proven load-bearing by reverting its class and watching exactly that test fail.

Fixes #2666

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSjVEjay9ztC1oDXXkh9uN

