### PR TITLE
fix(workspace): retain Main reply baseline before dispatch (#2730)

### DIFF
--- a/src/frontend/src/components/portal/PortalConversation.vue
+++ b/src/frontend/src/components/portal/PortalConversation.vue
@@ -742,7 +742,7 @@ import PortalAvatar from './PortalAvatar.vue'
 import PortalStarButton from './PortalStarButton.vue'
 import PortalEditableTitle from './PortalEditableTitle.vue'
 import PortalChatTabs from './PortalChatTabs.vue'
-import { newChatHotkeyLabel, MAIN_TAB_LABEL, composerAvailabilityNotice, assistantRow, replyFromHistory, replyBaseline } from './portalUtils'
+import { newChatHotkeyLabel, MAIN_TAB_LABEL, composerAvailabilityNotice, assistantRow, replyFromHistory, replyBaseline, readReplyBaseline } from './portalUtils'
 import { usePortalFileDrop, attachmentState } from '@/composables/usePortalFileDrop'
 import { useStickToBottom } from '@/composables/useStickToBottom'
 import PortalTypeahead from './PortalTypeahead.vue'
@@ -1991,13 +1991,10 @@ async function awaitPersistedReply(sessionId, baseline, budgetSeconds,
 // reply must differ from (#2694: by identity, read from the same narrow rows
 // the poll reads, so the two can never disagree about the window).
 async function persistedReplyBaseline(sessionId) {
-  if (!sessionId) return replyBaseline([])
-  try {
-    const data = await store.fetchHistory(props.agent.name, sessionId, { limit: REPLY_POLL_ROWS })
-    return replyBaseline(data.messages)
-  } catch {
-    return replyBaseline([])
-  }
+  return readReplyBaseline(
+    (resolved) => store.fetchHistory(props.agent.name, resolved, { limit: REPLY_POLL_ROWS }),
+    sessionId,
+  )
 }
 
 // Mark a sent message as undelivered, THROUGH the reactive array.

--- a/src/frontend/src/components/portal/portalUtils.js
+++ b/src/frontend/src/components/portal/portalUtils.js
@@ -2015,6 +2015,19 @@ export function replyBaseline(messages) {
   return { id: last?.id || null, count: typedReplyCount(messages) }
 }
 
+// A missing session id is not an empty conversation. The portal backend resolves
+// it to the pair's Main chat, so the baseline read must make the same request and
+// let the server name the thread. Otherwise Main's last reply looks new as soon
+// as the streaming dispatch adopts the resolved session.
+export async function readReplyBaseline(fetchHistory, sessionId) {
+  try {
+    const data = await fetchHistory(sessionId || null)
+    return replyBaseline(data?.messages)
+  } catch {
+    return replyBaseline([])
+  }
+}
+
 export function replyFromHistory(messages, baseline) {
   const last = latestTypedReply(messages)
   if (!last) return null

--- a/src/frontend/tests/unit/portalReplyRateable.spec.js
+++ b/src/frontend/tests/unit/portalReplyRateable.spec.js
@@ -20,7 +20,9 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { assistantRow, replyBaseline, replyFromHistory } from '@/components/portal/portalUtils'
+import * as portalUtils from '@/components/portal/portalUtils'
+
+const { assistantRow, replyBaseline, replyFromHistory } = portalUtils
 
 const read = (rel) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8')
 const CONV = read('../../src/components/portal/PortalConversation.vue')
@@ -153,6 +155,28 @@ describe('#2580 — replyFromHistory reads the row the server wrote', () => {
     const local = [{ role: 'assistant', content: 'prev', id: 'm0', source: null, voiceCallId: null },
                    { role: 'assistant', content: 'aloud', id: 'v1', source: 'voice', voiceCallId: 'c' }]
     expect(replyBaseline(local).id).toBe('m0')
+  })
+})
+
+describe('Workspace reply baseline follows the server-resolved thread', () => {
+  it('keeps Main’s previous reply when dispatch begins without a session id', async () => {
+    const previous = {
+      id: 'm-previous', role: 'assistant', content: 'the prior answer', cost: null,
+      created_at: '2026-09-11T16:00:00.000000Z', source: null, voice_call_id: null,
+    }
+    const fetchHistory = async (sessionId) => {
+      expect(sessionId).toBeNull()
+      return {
+        sessionId: 'main-session', messages: [previous],
+        inFlightExecutionId: null, inFlightWaitBudgetSeconds: null,
+        lastTurnOutcome: null, truncated: false,
+      }
+    }
+
+    const baseline = await portalUtils.readReplyBaseline?.(fetchHistory, null)
+
+    expect(baseline).toEqual({ id: 'm-previous', count: 1 })
+    expect(replyFromHistory([previous], baseline)).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Description

Workspace now reads the persisted reply baseline even when the client has not yet adopted a session id. This matches the backend contract that resolves an absent session id to the agent/client pair's Main chat.

Previously, the frontend substituted an empty baseline. Once the streaming dispatch returned Main's session id, the first history poll could mistake Main's existing assistant row for the new turn's answer. The change moves the fallible baseline read into a small testable helper and preserves the existing empty fallback only when the history read actually fails.

## Related Issue

Fixes #2730

## Journey Impact

Journey Impact: extends: J03

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested this locally
- [x] New tests added (if applicable)
- [x] All existing tests pass

Verification after rebasing onto the latest `dev`:

- `npm run test:unit`: 125 files, 2,733 tests passed
- `npm run build`: passed
- `npm run check:tokens`: passed
- `git diff --check origin/dev...HEAD`: passed
- Mutation check: restoring the null-session early return makes the new regression fail while the other focused tests remain green

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation (not applicable; no API or user-facing contract change)
- [x] I have not committed any sensitive data (API keys, credentials, etc.)
- [x] I have added appropriate logging for new functionality (not applicable; no new functionality or backend path)

## Screenshots (if applicable)

Not applicable. The defect is reply attribution rather than visual layout, and the regression test covers the behavior without exposing a private conversation.
