### PR TITLE
fix(devex): stop the raw-colour scanner counting issue references

### DIFF
--- a/src/frontend/raw-color-baseline.json
+++ b/src/frontend/raw-color-baseline.json
@@ -17,6 +17,7 @@
     "also_absorbed": "19 files had IMPROVED below their old entries; those are now recorded at their real values, so the stale-ceiling check has something true to compare against.",
     "paying_down": "This freeze is a starting line, not an endorsement. Lowering an entry needs no ceremony \u2014 regenerate and the guard keeps biting at the new level.",
     "2638": "SubscriptionsPanel.vue raw_gray 165 -> 173 (+8): the API-key fallback toggle row. Not paid down because there is nothing to pay it down TO \u2014 `gray` is the sanctioned chrome family and tailwind.config.js defines no semantic neutral to replace it with (status-*/state-*/brand-*/accent-*/action-* are all meaning-carrying). The 8 classes are the label, the help text and the toggle's off-state, copied verbatim from the three identical toggles immediately above it; inventing a one-off semantic token for the fourth would make it the odd one out and leave the other three unconverted. Re-frozen in its own commit as the guard's own message prescribes, and scoped to this ONE entry rather than regenerated, so no unrelated drift is absorbed with it.",
+    "_2718_note": "2026-09-12, #2718: hardcoded_colors 456 -> 447 in 8 files, none of it a code change. The scanner counted a `#` followed by three or six hex digits anywhere in a <template>, so issue references in rendered copy ((ent#184), (#526), >#847</a>) were read as colours; ExecutionsPanel, OverviewPanel, ScheduleAnalyticsCard, settings/OperatorIntakePanel, settings/TelemetrySharingPanel, views/Settings and views/enterprise/Index each lose their only phantom, ReliabilityPanel both of its. Nothing else moves: raw_nongray, raw_gray and semantic_tokens are untouched, and no sample changes line.",
     "_2616_note": "2026-09-10, #2616: components/portal/PortalMarkdown.vue raw_gray 13 -> 34 (+21). The Workspace transcript had no typographic treatment at all; covering tables, headings, ordered lists, blockquotes and rules costs a surface/border/ink pair per element in BOTH themes, and those are gray by definition (the contract's 'everything else is gray'). raw_nongray stays 0 and hardcoded_colors stays 0."
   },
   "files": {
@@ -158,7 +159,7 @@
     "src/frontend/src/components/ExecutionsPanel.vue": {
       "raw_nongray": 28,
       "raw_gray": 125,
-      "hardcoded_colors": 1
+      "hardcoded_colors": 0
     },
     "src/frontend/src/components/ExposedToolsPanel.vue": {
       "raw_nongray": 0,
@@ -293,7 +294,7 @@
     "src/frontend/src/components/OverviewPanel.vue": {
       "raw_nongray": 0,
       "raw_gray": 150,
-      "hardcoded_colors": 1
+      "hardcoded_colors": 0
     },
     "src/frontend/src/components/PermissionsPanel.vue": {
       "raw_nongray": 0,
@@ -328,7 +329,7 @@
     "src/frontend/src/components/ReliabilityPanel.vue": {
       "raw_nongray": 26,
       "raw_gray": 24,
-      "hardcoded_colors": 2
+      "hardcoded_colors": 0
     },
     "src/frontend/src/components/ReplayTimeline.vue": {
       "raw_nongray": 12,
@@ -363,7 +364,7 @@
     "src/frontend/src/components/ScheduleAnalyticsCard.vue": {
       "raw_nongray": 0,
       "raw_gray": 55,
-      "hardcoded_colors": 1
+      "hardcoded_colors": 0
     },
     "src/frontend/src/components/SchedulesPanel.vue": {
       "raw_nongray": 21,
@@ -838,7 +839,7 @@
     "src/frontend/src/components/settings/OperatorIntakePanel.vue": {
       "raw_nongray": 6,
       "raw_gray": 36,
-      "hardcoded_colors": 1
+      "hardcoded_colors": 0
     },
     "src/frontend/src/components/settings/PortalSessionPolicyPanel.vue": {
       "raw_nongray": 30,
@@ -868,7 +869,7 @@
     "src/frontend/src/components/settings/TelemetrySharingPanel.vue": {
       "raw_nongray": 0,
       "raw_gray": 60,
-      "hardcoded_colors": 1
+      "hardcoded_colors": 0
     },
     "src/frontend/src/components/settings/TemplateRegistryPanel.vue": {
       "raw_nongray": 0,
@@ -993,7 +994,7 @@
     "src/frontend/src/views/Settings.vue": {
       "raw_nongray": 59,
       "raw_gray": 690,
-      "hardcoded_colors": 1
+      "hardcoded_colors": 0
     },
     "src/frontend/src/views/SetupPassword.vue": {
       "raw_nongray": 0,
@@ -1008,13 +1009,13 @@
     "src/frontend/src/views/enterprise/Index.vue": {
       "raw_nongray": 9,
       "raw_gray": 27,
-      "hardcoded_colors": 1
+      "hardcoded_colors": 0
     }
   },
   "totals": {
     "raw_nongray": 815,
     "raw_gray": 8744,
-    "hardcoded_colors": 456,
+    "hardcoded_colors": 447,
     "semantic_tokens": 4020,
     "files_with_violations": 198
   }

--- a/src/frontend/scripts/scan-raw-colors.mjs
+++ b/src/frontend/scripts/scan-raw-colors.mjs
@@ -73,7 +73,10 @@ const SEMANTIC_RE = new RegExp(
   `(?<![\\w-])(${VARIANT})${UTIL}-(${SEMANTIC_TOKENS.join('|')})-${SHADE}(?:\\/\\d{1,3})?(?![\\w-])`, 'g')
 
 // Hex literal (not an HTML entity like &#160;) and rgb()/rgba() with a numeric body.
-const HEX_RE = /(?<!&)#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{3,4})\b/g
+// The (?<![\\w&]) guard refuses an HTML entity (&#160;) and a `#` glued to a word,
+// which is what an issue reference looks like in copy: `(ent#184)` is not a colour
+// (#2718). A hex literal is never preceded by a word character.
+const HEX_RE = /(?<![\w&])#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{3,4})\b/g
 const RGB_RE = /\brgba?\(\s*\d[^)]*\)/g
 
 // ---------------------------------------------------------------- helpers
@@ -107,15 +110,77 @@ function lineOf(content, index) {
   return line
 }
 
-/** Extract [start, end) offset ranges of <template> and <style> blocks of a .vue file. */
+/** Extract [start, end, kind) offset ranges of <template> and <style> blocks of a .vue file. */
 function vueTemplateStyleRanges(content) {
   const ranges = []
   const t = content.match(/<template[^>]*>[\s\S]*<\/template>/) // greedy: nested </template> safe
-  if (t) ranges.push([t.index, t.index + t[0].length])
+  if (t) ranges.push([t.index, t.index + t[0].length, 'template'])
   for (const s of content.matchAll(/<style[^>]*>[\s\S]*?<\/style>/g)) {
-    ranges.push([s.index, s.index + s[0].length])
+    ranges.push([s.index, s.index + s[0].length, 'style'])
   }
   return ranges
+}
+
+/** Blank a text run but keep `{{ }}` interpolations, which are expressions, not copy. */
+function blankProse(text) {
+  let out = '', i = 0
+  while (i < text.length) {
+    const open = text.indexOf('{{', i)
+    if (open < 0) { out += blank(text.slice(i)); break }
+    out += blank(text.slice(i, open))
+    const close = text.indexOf('}}', open)
+    if (close < 0) { out += text.slice(open); break }
+    out += text.slice(open, close + 2)
+    i = close + 2
+  }
+  return out
+}
+
+/** Blank the rendered copy of a <template> block, preserving offsets (#2718).
+ *
+ * `#190` is a valid three-digit hex and also what an issue reference looks like,
+ * and rendered text is the one place in a .vue file where a colour cannot appear.
+ * Tags, attribute values and interpolations are code and stay scanned; the copy
+ * between them does not. Offsets are preserved, so sample line numbers hold.
+ *
+ * Quote aware on purpose: `v-if="nowX >= 0"` would otherwise end the tag early
+ * and blank the stroke="#10b981" that follows it.
+ */
+function blankTemplateProse(block) {
+  let out = '', i = 0
+  while (i < block.length) {
+    const lt = block.indexOf('<', i)
+    out += blankProse(block.slice(i, lt < 0 ? block.length : lt))
+    if (lt < 0) break
+    let j = lt + 1, quote = null
+    while (j < block.length) {
+      const ch = block[j]
+      if (quote) { if (ch === quote) quote = null }
+      else if (ch === '"' || ch === "'") quote = ch
+      else if (ch === '>') break
+      j++
+    }
+    out += block.slice(lt, Math.min(j + 1, block.length))
+    i = j + 1
+  }
+  return out
+}
+
+/** Hardcoded colours in the template/style blocks of one .vue source. */
+export function countHardcodedColors(source, onSample) {
+  const content = stripComments(source)
+  let n = 0
+  for (const [start, end, kind] of vueTemplateStyleRanges(content)) {
+    const span = content.slice(start, end)
+    const block = kind === 'template' ? blankTemplateProse(span) : span
+    for (const re of [HEX_RE, RGB_RE]) {
+      for (const m of block.matchAll(re)) {
+        n++
+        onSample?.({ line: lineOf(content, start + m.index), text: m[0], kind: 'hardcoded' })
+      }
+    }
+  }
+  return n
 }
 
 function collect(content, re, file, samples, kind) {
@@ -172,18 +237,9 @@ export function scanRawColors(rootArg) {
     const semantic = collect(content, SEMANTIC_RE)
 
     // 2. hardcoded colors — .vue template/style blocks only
-    let hardcoded = 0
-    if (file.endsWith('.vue')) {
-      for (const [start, end] of vueTemplateStyleRanges(content)) {
-        const block = content.slice(start, end)
-        for (const re of [HEX_RE, RGB_RE]) {
-          for (const m of block.matchAll(re)) {
-            hardcoded++
-            fileSamples.push({ line: lineOf(content, start + m.index), text: m[0], kind: 'hardcoded' })
-          }
-        }
-      }
-    }
+    const hardcoded = file.endsWith('.vue')
+      ? countHardcodedColors(raw, (sample) => fileSamples.push(sample))
+      : 0
 
     // 3. spot-checks
     for (const m of content.matchAll(/overflow-x-auto/g)) {

--- a/src/frontend/tests/unit/rawColorRatchet.spec.js
+++ b/src/frontend/tests/unit/rawColorRatchet.spec.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
-import { scanRawColors, baselineKey } from '../../scripts/scan-raw-colors.mjs'
+import { scanRawColors, baselineKey, countHardcodedColors } from '../../scripts/scan-raw-colors.mjs'
 
 /**
  * #2605 — raw-colour RATCHET, actually enforced.
@@ -144,5 +144,54 @@ describe('the docs describe what is actually enforced (#2605)', () => {
     for (const doc of ['CLAUDE.md', 'docs/memory/design-system-contract.md']) {
       expect(read(doc), doc).toContain('rawColorRatchet.spec.js')
     }
+  })
+})
+
+
+/**
+ * #2718 — what counts as a hardcoded colour.
+ *
+ * `#190` is a valid three-digit hex and also what an issue reference looks like
+ * in rendered copy, so the scanner counted `(ent#184)` and `>#847</a>` as
+ * colours. Nine such phantoms sat in the baseline, and the ratchet above turned
+ * them load-bearing: adding a second reference to a file grew its entry and
+ * failed the build for prose.
+ *
+ * The rule is positional, because no lexical one can separate the two: code is
+ * scanned, rendered copy is not. Tags, attribute values and `{{ }}`
+ * interpolations stay in; the text between them does not.
+ */
+describe('scanner: a hardcoded colour, and not an issue number (#2718)', () => {
+  const count = (source) => countHardcodedColors(source)
+
+  it('does not count an issue reference in copy', () => {
+    expect(count('<template>\n  <p>Opt-in per agent (#526).</p>\n</template>')).toBe(0)
+    expect(count('<template>\n  <p>quality (ent#184)</p>\n</template>')).toBe(0)
+    expect(count('<template>\n  <a href="https://example.test/issues/847">#847</a>\n</template>')).toBe(0)
+  })
+
+  it('does not count an issue reference glued to a word inside an attribute', () => {
+    expect(count('<template>\n  <p title="quality (ent#206)">x</p>\n</template>')).toBe(0)
+  })
+
+  it('does not count an HTML entity', () => {
+    expect(count('<template>\n  <p>a&#160;b</p>\n</template>')).toBe(0)
+  })
+
+  it('still counts a hex literal in an attribute, a style block and an arbitrary class', () => {
+    expect(count('<template>\n  <div style="color:#1a2b3c">x</div>\n</template>')).toBe(1)
+    expect(count('<template>\n  <div class="bg-[#1e1e1e]">x</div>\n</template>')).toBe(1)
+    expect(count('<style>\n.a { border: 1px solid #374151; color: #fff }\n</style>')).toBe(2)
+    expect(count('<style>\n.a { background: rgba(0, 0, 0, .5) }\n</style>')).toBe(1)
+  })
+
+  it('still counts a hex behind an attribute holding a > character', () => {
+    // The tag scan is quote aware: `v-if="a > b"` must not end the tag early and
+    // take the stroke colour after it with the copy.
+    expect(count('<template>\n  <path v-if="nowX >= 0" stroke="#10b981" />\n</template>')).toBe(1)
+  })
+
+  it('still counts a hex inside an interpolation, which is an expression', () => {
+    expect(count("<template>\n  <p>{{ ok ? '#10b981' : '#ef4444' }}</p>\n</template>")).toBe(2)
   })
 })


### PR DESCRIPTION
## Description

`scan-raw-colors.mjs` matched a `#` followed by three or six hex digits anywhere inside a `<template>` or `<style>` block. A three-digit hex is also what an issue reference looks like in rendered copy, so `(ent#184)`, `Opt-in per agent (#526).` and `<a …>#847</a>` were counted as hardcoded colours. Nine of them sat in `raw-color-baseline.json`, and since #2605 made the ratchet actually bite, that turned load-bearing: adding a second reference to a file grows its entry and fails the build for prose.

No lexical rule separates the two, since `#190` is both. The rule here is positional, and it is the one the file already implies: code is scanned, rendered copy is not.

- `HEX_RE` refuses a `#` glued to a word, `(?<![\w&])`, which catches the `ent#206` shape even inside a prose attribute such as `title="quality (ent#206)"`. A hex literal is never preceded by a word character, so `1px solid #374151` and `bg-[#1e1e1e]` are unaffected.
- The copy of a `<template>` is blanked before matching, offsets preserved so sample line numbers still point at the source. Tags, attribute values and `{{ }}` interpolations stay in, so `stroke="#10b981"` and `{{ ok ? '#10b981' : '#ef4444' }}` are still counted. `<style>` blocks are never blanked.
- The tag scan is quote aware, because `v-if="nowX >= 0"` would otherwise end the tag early and blank the colour that follows it. `ReplayTimeline.vue` has exactly that shape.

The prescription in the issue, the `\w` lookbehind alone, removes only the `ent#NNN` half: `#190`, `(#526)` and `>#847<` are not preceded by a word character. Both halves are needed, and the spec fails if either is reverted.

Measured on this branch, nothing else moves:

| | before | after |
| --- | --- | --- |
| hardcoded_colors | 456 | 447 |
| raw_nongray | 815 | 815 |
| raw_gray | 8752 | 8752 |
| semantic_tokens | 4034 | 4034 |

The nine are `ExecutionsPanel:54`, `OverviewPanel:359`, `ReliabilityPanel:7` and `:74`, `ScheduleAnalyticsCard:46`, `settings/OperatorIntakePanel:9`, `settings/TelemetrySharingPanel:9`, `views/Settings:1251`, `views/enterprise/Index:118`. No surviving sample changes line.

The baseline is hand-edited, 8 entries plus the total, rather than regenerated: `--baseline` rewrites the file and would drop the hand-written `refrozen` provenance. A `_2718_note` is added there in the style of the existing ones.

## Related Issue

Fixes #2718

## Journey Impact

Journey Impact: none: a scanner accuracy fix in the devex tooling; it changes no user-facing behaviour and no promise in tests/journeys/catalog.yaml.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- [x] I have tested this locally
- [x] New tests added (if applicable)
- [x] All existing tests pass

`countHardcodedColors(source, onSample)` is exported so the spec can drive it with literal snippets, the way `loadingGateRatchet.spec.js` drives `countBareLoadingGates`. Seven cases in `tests/unit/rawColorRatchet.spec.js` under `#2718`: issue references in copy, in an attribute and as link text, an HTML entity, hex in an attribute, in an arbitrary class, in a `<style>` block, `rgba()`, a hex behind an attribute containing `>`, and a hex inside an interpolation.

```
npx vitest run tests/unit/rawColorRatchet.spec.js     14 passed
npm run test:unit                                     2737 passed, 1 failed
npm run check:tokens                                  OK
```

The one failure is `tests/unit/canvasUtils.spec.js > a date axis keeps the default spacing`, which fails the same way on `dev` without this branch.

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation (if applicable)
- [x] I have not committed any sensitive data (API keys, credentials, etc.)
- [ ] I have added appropriate logging for new functionality

One documentation note left deliberately: `docs/memory/learnings.md` still records the durable scanner fix as open debt. Happy to update it here if you would rather it land together.
