### PR TITLE
feat(workspace): the rail's scrollbar is thin, hidden at rest and revealed on hover or scroll (abilityai/trinity-enterprise#608)

### DIFF
--- a/docs/memory/feature-flows/workspace-rail.md
+++ b/docs/memory/feature-flows/workspace-rail.md
@@ -456,6 +456,50 @@ reviewer clicks.
   component's own source guards (an `<img>`, no `v-html`, capture + preventDefault,
   `revokeObjectURL`, no `Range`, zero raw palette classes).
 
+## The body's scrollbar — thin, hidden at rest (trinity-enterprise#608)
+
+The rail's single scroll axis (`data-testid="portal-rail-body"`, principle 8)
+used to show a stock scrollbar: the global `.dark ::-webkit-scrollbar` 8px bar
+in dark mode, the browser default in light — and because *any*
+`::-webkit-scrollbar` rule opts an element out of macOS overlay scrollbars, a
+dark-mode Mac saw an always-on bar where the light rail hid its bar when idle.
+The two themes disagreed about scrollbar weight.
+
+`rail-scroll`, a scoped style on that one container, makes both behave like the
+good case and thinner: `scrollbar-width: thin` with `scrollbar-color:
+transparent transparent` at rest, the tertiary ink (`theme('colors.gray.500 /
+0.55')` light, `gray.400 / 0.5` dark — resolved at build, hence an explicit
+`.dark` override, the ScanlineReveal precedent) on `:hover` / `:focus-within`,
+with a 150ms `scrollbar-color` transition — and on `.is-scrolling`, a class the
+body's passive `scroll` listener holds for ~800ms past the last event. That
+third arm was found in the capture, not designed in: Chromium on a Mac in the
+default "show scroll bars: automatically" mode renders the standard-property
+bar as a native overlay, which shows during scrolling only and never on hover,
+so with the rest colour transparent the first cut showed no bar at all, in
+either theme, in any state. A parallel `::-webkit-scrollbar*`
+block gives Safari the same 6px rounded thumb on a transparent track with the
+same two states; in Chromium the standard pair wins and the WebKit rules are
+ignored, which is why the two blocks must stay visually identical rather than
+being two designs.
+
+**What reveal may change: colour, nothing else.** Toggling `display: none`,
+`width`, `scrollbar-width` or `overflow` on hover reflows the whole tab body
+(every line re-wraps as the gutter comes and goes) — the anti-pattern the issue
+excludes. The proof is mechanical: the feel-check capture reads every
+descendant's `getBoundingClientRect` at rest and hovered and asserts the two
+serialisations are equal, in both themes. The thin bar therefore keeps its
+gutter in classic-scrollbar mode (Windows/Linux defaults, macOS "Show scroll
+bars: Always"); it is the rest-state *visibility* that changes, not the
+geometry. Under `prefers-reduced-motion` the transition is off.
+
+The rule is wrapped in `@media (min-width: 640px)` (Tailwind `sm`): the
+below-`sm` sheet is the same component, but touch platforms already overlay
+their scrollbars natively and are left native. The global dark rule in
+`style.css` is untouched — the sidebar list (`PortalSidebar.vue`) and the
+transcript (`PortalConversation.vue` `scrollEl`) are a follow-up if the feel
+lands, not this change. Guard: `portalRail.spec.js` pins the body's class
+string with `rail-scroll` on it.
+
 ## Residuals (stated)
 
 - The Work signal is store-derived since ent#525 (`workspace-work.md`): the owner merges

--- a/docs/memory/requirements/core-agent.md
+++ b/docs/memory/requirements/core-agent.md
@@ -1399,6 +1399,30 @@ well, and the agent never touches CSS.
 - **AC-8 — the empty state teaches**: "Nothing running right now" + **See what
   you can ask** — scrolls to the briefing hints when they are on screen, else
   opens the agent page's "what it can do".
+- **AC-9 — the body's scrollbar is thin and hidden at rest
+  (trinity-enterprise#608)**: the rail's one scroll axis wears the
+  overlay-scrollbar convention of editor panels — a ~6px rounded thumb on a
+  transparent track, invisible until the pointer is over the scroll region,
+  focus is inside it, or the body is scrolling (`:hover` / `:focus-within` /
+  an `is-scrolling` class held ~800ms past the last `scroll` event), fading
+  rather than popping. The scroll arm is not optional on macOS: in the default
+  "show scroll bars: automatically" mode the platform never reveals an overlay
+  bar on hover, only during scrolling — and with the rest colour transparent
+  it would otherwise show nothing, ever.
+  Reveal changes the thumb's colour ONLY — never `display`, `width`,
+  `scrollbar-width` or `overflow` — so content wraps byte-identically hovered
+  or not; the thin bar keeps its gutter in classic-scrollbar mode by design.
+  The affordance is hidden, the capability is not (wheel, trackpad, touch and
+  focus-into-view all work at rest — the #1789 bar). Both engines, one look:
+  the standard `scrollbar-width: thin` + `scrollbar-color` pair (Firefox,
+  Chromium ≥121, where it also disables the `::-webkit-scrollbar` rules) and the
+  WebKit pseudo-elements for Safari. The thumb is the tertiary ink of each
+  theme (gray-500 light / gray-400 dark) at reduced alpha, stronger under the
+  pointer; `sm:`-and-up only, so the mobile sheet keeps its native overlay
+  bars. Scoped to `PortalRail.vue` — the global `.dark ::-webkit-scrollbar`
+  rule in `style.css` is untouched; the sidebar list and the conversation
+  transcript are a follow-up once the feel is confirmed. Gated on a human feel
+  check on the running instance before the PR.
 - **Not in this slice (recorded on the issue)**: the Work tab's content
   (#457), re-homing Loops / Canvas / Files (#472's second child), the sidebar /
   thread tab strip / top band / Agent-details panel / drop target of the

--- a/src/frontend/src/components/portal/PortalRail.vue
+++ b/src/frontend/src/components/portal/PortalRail.vue
@@ -109,8 +109,17 @@
         </div>
 
         <!-- The body: the rail's own scroll axis. Exactly ONE tab's content is
-             mounted, and only a tab from `tabs` can be `active`. -->
-        <div v-if="active" class="flex-1 min-h-0 overflow-y-auto p-4" data-testid="portal-rail-body">
+             mounted, and only a tab from `tabs` can be `active`. `rail-scroll`
+             is the ent#608 scrollbar chrome (the <style> below): thin, hidden
+             at rest, revealed on hover / focus-within / while scrolling, never
+             reflowing. -->
+        <div
+          v-if="active"
+          class="flex-1 min-h-0 overflow-y-auto p-4 rail-scroll"
+          :class="{ 'is-scrolling': scrolling }"
+          data-testid="portal-rail-body"
+          @scroll.passive="onBodyScroll"
+        >
           <slot
             :name="`tab-${active.id}`"
             :tab="active"
@@ -164,7 +173,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, onBeforeUnmount } from 'vue'
+import { computed, onMounted, onBeforeUnmount, ref } from 'vue'
 import OverflowTabs from '../OverflowTabs.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import BaseBadge from '@/components/base/BaseBadge.vue'
@@ -236,7 +245,24 @@ function onKeydown(e) {
   if (e.key === 'Escape' && props.sheet) emit('close')
 }
 onMounted(() => { if (props.sheet) window.addEventListener('keydown', onKeydown) })
-onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeydown)
+  clearTimeout(scrollTimer)
+})
+
+// ent#608 — the thumb also shows WHILE the body scrolls, for ~800ms after the
+// last scroll event. CSS alone cannot reveal on wheel-without-hover, and on a
+// Mac in "show scroll bars: automatically" mode the platform never reveals an
+// overlay bar on hover at all — its bar shows during scrolling only, and with
+// the rest colour transparent it would show nothing, ever. A class flip only:
+// the colour is the one thing the reveal changes (see the <style> below).
+const scrolling = ref(false)
+let scrollTimer = null
+function onBodyScroll() {
+  scrolling.value = true
+  clearTimeout(scrollTimer)
+  scrollTimer = setTimeout(() => { scrolling.value = false }, 800)
+}
 
 // ---- ink ----------------------------------------------------------------------
 // Design pass values: collapsed 48px (`w-12`), open 384px (`w-96`), 36px
@@ -286,3 +312,79 @@ function iconPath(tabId) {
   return ICONS[tab && tab.icon] || ICONS.bolt
 }
 </script>
+
+<style scoped>
+/*
+ * ent#608 — the rail body's scrollbar: thinner, invisible at rest, revealed
+ * while the pointer is over the scroll region, focus is inside it, or the
+ * body is scrolling (`is-scrolling`, set by `onBodyScroll` above).
+ *
+ * The overlay-scrollbar convention (editor panels, chat sidebars): the
+ * affordance is hidden, the capability is not — wheel, trackpad, touch and
+ * focus-into-view all work at rest (the #1789 bar). Reveal changes the
+ * thumb's COLOUR only. Never `display`, `width`, `scrollbar-width` or
+ * `overflow` — any of those reflows the whole tab body on hover, which is
+ * the anti-pattern the issue excludes. The thin bar keeps its gutter in
+ * classic-scrollbar mode by design; it is the rest-state visibility that
+ * changes, not the geometry, so content wraps identically hovered or not.
+ *
+ * Two engines, one look. Chromium (≥121) and Firefox read the standard
+ * `scrollbar-width` / `scrollbar-color` pair — and once either is set,
+ * Chromium ignores every `::-webkit-scrollbar*` rule on the element, so the
+ * standard pair is the primary path. The WebKit block is Safari's, and is
+ * kept visually identical: a ~6px rounded thumb on a transparent track.
+ *
+ * Thumb ink is the design-system tertiary (gray-500 light / gray-400 dark —
+ * the dark ink ladder), slightly stronger under the pointer. theme() resolves
+ * at build (there is no global token var layer — the ScanlineReveal
+ * precedent), hence the explicit `.dark` override. The below-`sm` sheet is
+ * the same component, but touch platforms already overlay their scrollbars
+ * natively; the rule is `sm:`-and-up only so the sheet stays native.
+ */
+@media (min-width: 640px) {
+  .rail-scroll {
+    --rail-thumb: theme('colors.gray.500 / 0.55');
+    --rail-thumb-strong: theme('colors.gray.500 / 0.85');
+    scrollbar-width: thin;
+    scrollbar-color: transparent transparent;
+    transition: scrollbar-color 0.15s ease;
+  }
+  .dark .rail-scroll {
+    --rail-thumb: theme('colors.gray.400 / 0.5');
+    --rail-thumb-strong: theme('colors.gray.400 / 0.8');
+  }
+  .rail-scroll:hover,
+  .rail-scroll:focus-within,
+  .rail-scroll.is-scrolling {
+    scrollbar-color: var(--rail-thumb) transparent;
+  }
+
+  /* WebKit — same rest/hover states, fixed width so nothing reflows. */
+  .rail-scroll::-webkit-scrollbar {
+    width: 6px;
+  }
+  .rail-scroll::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .rail-scroll::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+    transition: background-color 0.15s ease;
+  }
+  .rail-scroll:hover::-webkit-scrollbar-thumb,
+  .rail-scroll:focus-within::-webkit-scrollbar-thumb,
+  .rail-scroll.is-scrolling::-webkit-scrollbar-thumb {
+    background-color: var(--rail-thumb);
+  }
+  .rail-scroll:hover::-webkit-scrollbar-thumb:hover {
+    background-color: var(--rail-thumb-strong);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rail-scroll,
+  .rail-scroll::-webkit-scrollbar-thumb {
+    transition: none;
+  }
+}
+</style>

--- a/src/frontend/tests/unit/portalRail.spec.js
+++ b/src/frontend/tests/unit/portalRail.spec.js
@@ -516,8 +516,47 @@ describe('ent#474 — the rail component (source guards)', () => {
   })
 
   it('mounts a body for exactly the active visible tab', () => {
-    expect(rail).toContain('<div v-if="active" class="flex-1 min-h-0 overflow-y-auto p-4"')
+    // ent#608: `rail-scroll` is the body's scrollbar chrome — thin, hidden at
+    // rest, revealed on hover — and rides the same class string.
+    expect(rail).toMatch(/<div\n\s+v-if="active"\n\s+class="flex-1 min-h-0 overflow-y-auto p-4 rail-scroll"/)
     expect(rail).toContain(':name="`tab-${active.id}`"')
+  })
+
+  // ent#608 — the body's scrollbar: thin, hidden at rest, revealed on hover /
+  // focus-within / while scrolling, and the reveal changes colour ONLY.
+  describe('ent#608 — the body scrollbar chrome', () => {
+    const style = rail.slice(rail.indexOf('<style scoped>'))
+
+    it('hides the thumb at rest on both engines and reveals it on hover, focus-within and scroll', () => {
+      expect(style).toMatch(/\.rail-scroll \{[^}]*scrollbar-width: thin;[^}]*scrollbar-color: transparent transparent;/)
+      expect(style).toMatch(/\.rail-scroll::-webkit-scrollbar-thumb \{[^}]*background-color: transparent;/)
+      expect(style).toMatch(/\.rail-scroll:hover,\n\s+\.rail-scroll:focus-within,\n\s+\.rail-scroll\.is-scrolling \{\n\s+scrollbar-color: var\(--rail-thumb\) transparent;/)
+      expect(style).toMatch(/\.rail-scroll:hover::-webkit-scrollbar-thumb,\n\s+\.rail-scroll:focus-within::-webkit-scrollbar-thumb,\n\s+\.rail-scroll\.is-scrolling::-webkit-scrollbar-thumb \{\n\s+background-color: var\(--rail-thumb\);/)
+      expect(rail).toContain(':class="{ \'is-scrolling\': scrolling }"')
+      expect(rail).toContain('@scroll.passive="onBodyScroll"')
+      expect(rail).toContain('clearTimeout(scrollTimer)')
+    })
+
+    it('never reflows on reveal: the revealed states set colour only, and the WebKit width is fixed', () => {
+      // Every rule whose selector carries a reveal state may set colour and nothing else.
+      const revealRules = [...style.matchAll(/((?:\.rail-scroll[^{]*(?::hover|:focus-within|\.is-scrolling)[^{]*)\{([^}]*)\})/g)]
+      expect(revealRules.length).toBeGreaterThanOrEqual(3)
+      for (const [, , body] of revealRules) {
+        const props = body.split(';').map((l) => l.trim().split(':')[0]).filter(Boolean)
+        expect(props.every((p) => p === 'scrollbar-color' || p === 'background-color')).toBe(true)
+      }
+      expect(style).toMatch(/\.rail-scroll::-webkit-scrollbar \{\n\s+width: 6px;\n\s+\}/)
+      expect(style).not.toMatch(/display:\s*none/)
+      expect(style).not.toMatch(/scrollbar-gutter/)
+    })
+
+    it('is tokens on both themes, sm-and-up only, and still under prefers-reduced-motion', () => {
+      expect(style).toMatch(/\.rail-scroll \{[^}]*--rail-thumb: theme\('colors\.gray\.500 \/ [\d.]+'\)/)
+      expect(style).toMatch(/\.dark \.rail-scroll \{[^}]*--rail-thumb: theme\('colors\.gray\.400 \/ [\d.]+'\)/)
+      expect(style).not.toMatch(/#[0-9a-fA-F]{3,8}\b/)
+      expect(style).toContain('@media (min-width: 640px)')
+      expect(style).toMatch(/@media \(prefers-reduced-motion: reduce\) \{[^}]*\.rail-scroll[^}]*transition: none/)
+    })
   })
 
   it('is the approved width in each form, with the sheet on the files-panel pattern', () => {


### PR DESCRIPTION
## Summary
- The Workspace rail's tab body (`data-testid="portal-rail-body"`, its one scroll axis) gets a scoped `rail-scroll` style: `scrollbar-width: thin` with a transparent `scrollbar-color` at rest, the tertiary ink (gray-500 light / gray-400 dark, reduced alpha) revealed on `:hover` / `:focus-within` / `.is-scrolling`, 150ms fade, and a matching 6px rounded-thumb `::-webkit-scrollbar*` block for Safari. Reveal changes **colour only** — never display / width / scrollbar-width / overflow — so nothing reflows. `sm:`-and-up only (the mobile sheet stays native); transition off under `prefers-reduced-motion`.
- `is-scrolling` is a passive `scroll` listener holding a class ~800ms past the last event. Found in the capture, not designed in: Chromium on a Mac in the default "show scroll bars automatically" mode renders the standard-property bar as a native overlay that shows during scrolling only and never on hover, so with the rest colour transparent the CSS-only cut showed no bar at all.
- Scope is the rail only: the global `.dark ::-webkit-scrollbar` rule in `style.css` is untouched; the sidebar list and the conversation transcript are a follow-up per the issue.

## Changes
- `src/frontend/src/components/portal/PortalRail.vue` — `rail-scroll` class + `is-scrolling` binding on the body, the scroll listener (cleared on unmount), the scoped style block.
- `src/frontend/tests/unit/portalRail.spec.js` — three source guards (hidden at rest on both engines and revealed on hover/focus/scroll; reveal rules set colour only and the WebKit width is fixed; tokens on both themes, `sm`-and-up, reduced-motion). The existing guard pinning the body's class string now includes `rail-scroll` (the one way to add the class to that string).
- `docs/memory/requirements/core-agent.md` — AC-9 under 5.19 (the rail shell).
- `docs/memory/feature-flows/workspace-rail.md` — the scrollbar section.

## Test Plan
- [x] `npm run test:unit` — 125 files, 2735 tests pass (raw-color and loading-gate ratchets unchanged); `npm run check:tokens` OK
- [x] Layout stability proved mechanically: every descendant's `getBoundingClientRect` at rest vs hovered serialises identically, both themes (Playwright, Chromium)
- [x] Human feel check confirmed by the requester on the issue before this PR was opened (both themes, Chrome on macOS) — abilityai/trinity-enterprise#608
- [ ] Safari (WebKit block) and classic-scrollbar mode (Windows/Linux, macOS "Always") — verified by source only; the standard pair and the WebKit block are kept visually identical

Fixes abilityai/trinity-enterprise#608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LigrhfzBXbTBCdoeQ69if