### PR TITLE
fix(portal): preview a shared file same-origin whatever origin its url carries

### DIFF
--- a/src/frontend/src/components/portal/portalFiles.js
+++ b/src/frontend/src/components/portal/portalFiles.js
@@ -159,16 +159,31 @@ export function fileActions(row, { owned = false } = {}) {
 }
 
 /**
+ * Routes the backend serves on EVERY hostname that fronts it. The portal page's
+ * own origin proxies `/api/*`, so a url under this prefix names bytes that are
+ * reachable same-origin whatever origin it was minted with.
+ */
+const BACKEND_API_PREFIX = '/api/'
+
+/**
  * A same-origin path for a `download_url` that may be absolute or relative.
  *
  * `base` is required because `portal_documents` emits a RELATIVE url whenever
  * no portal base URL is configured (`get_portal_base_url()` falls back to
  * `public_chat_url`, which can be `''`), and `new URL(relative)` throws.
  *
- * The invariant this rests on: the portal page and `/api` are same-origin by
- * construction. A deployment that configures a portal base URL pointing
- * somewhere else has a cross-origin fetch, and that is the deployment's problem
- * — we return the URL unchanged rather than pretending otherwise.
+ * A portal base URL that resolves to ANOTHER origin is a supported production
+ * topology, not a misconfiguration: a deployment may front its agents on a
+ * dedicated public hostname while the portal page is served from the app
+ * hostname (#2733). For `/api/*` that origin is decoration — the same backend
+ * answers on both, and a share's authority is its `?sig=` token rather than the
+ * hostname the url was built with — so the url is reduced to a path and the
+ * fetch stays inside CSP `connect-src 'self'`. Widening the CSP instead is not
+ * available: the portal base URL is a runtime setting and cannot be baked into
+ * a static nginx or Vite header.
+ *
+ * Any other cross-origin url is returned unchanged. Reducing one to a path
+ * would point the fetch at a route this origin does not serve.
  */
 export function sameOriginPath(url, base = '') {
   const raw = String(url || '')
@@ -176,7 +191,8 @@ export function sameOriginPath(url, base = '') {
   try {
     const parsed = new URL(raw, base || 'http://localhost')
     const origin = base ? new URL(base).origin : null
-    if (origin && parsed.origin !== origin) return raw
+    const crossOrigin = origin !== null && parsed.origin !== origin
+    if (crossOrigin && !parsed.pathname.startsWith(BACKEND_API_PREFIX)) return raw
     return `${parsed.pathname}${parsed.search}`
   } catch {
     return raw
@@ -224,7 +240,15 @@ export async function errorDetail(err, fallback = 'Something went wrong.') {
   return fallback
 }
 
-/** Mark a preview read without mutating the original download URL. */
+/**
+ * Mark a preview read without mutating the original download URL.
+ *
+ * The result is always same-origin for the `/api/files/...` url a share
+ * carries, so the preview `fetch()` is permitted by `connect-src 'self'` even
+ * when `download_url` was built off a portal base URL on another hostname
+ * (#2733). Download keeps the absolute url: it is the shareable link, and it
+ * saves through an anchor, which `connect-src` does not govern.
+ */
 export function sharePreviewPath(url, base) {
   const parsed = new URL(url, base)
   parsed.searchParams.set('preview', '1')

--- a/src/frontend/tests/unit/portalFiles.spec.js
+++ b/src/frontend/tests/unit/portalFiles.spec.js
@@ -33,6 +33,7 @@ import {
   previewCapNotice,
   previewKind,
   sameOriginPath,
+  sharePreviewPath,
 } from '@/components/portal/portalFiles'
 
 const SRC = fileURLToPath(new URL('../../src', import.meta.url))
@@ -253,13 +254,62 @@ describe('#2582 — url and size helpers', () => {
   })
 
   it('leaves a genuinely cross-origin url alone rather than pretending', () => {
-    expect(sameOriginPath('https://elsewhere.example/api/files/f1', 'https://portal.example.com'))
-      .toBe('https://elsewhere.example/api/files/f1')
+    // Still the rule for anything OUTSIDE `/api/`: reducing such a url to a
+    // path would aim the fetch at a route this origin does not serve. The
+    // `/api/` case moved to the #2733 block below, where the same backend
+    // answers on both hostnames.
+    expect(sameOriginPath('https://elsewhere.example/static/logo.png', 'https://portal.example.com'))
+      .toBe('https://elsewhere.example/static/logo.png')
   })
 
   it('returns junk unchanged instead of throwing', () => {
     expect(sameOriginPath('')).toBe('')
     expect(sameOriginPath(null)).toBe('')
+  })
+
+  // -------------------------------------------------------------------------
+  // #2733 — a portal base URL on another origin is a supported topology
+  // -------------------------------------------------------------------------
+
+  it('reduces an /api/ url from a DIFFERENT origin to a path', () => {
+    // A deployment may front agents on a dedicated public hostname while the
+    // portal page is served from the app hostname, so `download_url` carries
+    // that other origin. The portal page's own origin proxies `/api/*`, so the
+    // bytes are reachable same-origin and the fetch must go there: CSP
+    // `connect-src 'self'` cannot list a per-deployment origin.
+    expect(sameOriginPath('https://files.example.com/api/files/f1?sig=t&download=1',
+                          'https://app.example.com'))
+      .toBe('/api/files/f1?sig=t&download=1')
+  })
+
+  it('previews a cross-origin share same-origin, keeping sig and preview', () => {
+    const path = sharePreviewPath('https://files.example.com/api/files/f1?sig=t&download=1',
+                                  'https://app.example.com')
+    expect(path.startsWith('/api/files/f1')).toBe(true)
+    expect(path).toContain('sig=t')
+    expect(path).toContain('preview=1')
+    expect(path).toContain('download=1')
+  })
+
+  it('previews a relative share exactly as before', () => {
+    // The default install has no portal base URL configured, so
+    // `portal_documents` emits a relative url. That path must not change.
+    expect(sharePreviewPath('/api/files/f1?sig=t&download=1', 'https://app.example.com'))
+      .toBe('/api/files/f1?sig=t&download=1&preview=1')
+  })
+
+  it('does not touch the download_url it was handed', () => {
+    // Download is an anchor navigation against the absolute url, which
+    // `connect-src` does not govern, so the shareable link must survive the
+    // preview rewrite untouched.
+    const downloadUrl = 'https://files.example.com/api/files/f1?sig=t&download=1'
+    sharePreviewPath(downloadUrl, 'https://app.example.com')
+    expect(downloadUrl).toBe('https://files.example.com/api/files/f1?sig=t&download=1')
+  })
+
+  it('still refuses to rewrite a cross-origin non-api url for preview', () => {
+    expect(sharePreviewPath('https://elsewhere.example/files/f1', 'https://app.example.com'))
+      .toBe('https://elsewhere.example/files/f1?preview=1')
   })
 
   it('states the cap only when something was actually truncated', () => {
@@ -499,7 +549,11 @@ describe('share preview URL', () => {
     expect(preview.searchParams.get('preview')).toBe('1')
     expect(preview.searchParams.get('download')).toBe('1')
     expect(download).not.toContain('preview')
+    // #2733 reversed this line. A portal base URL on another hostname is a
+    // supported topology, and `connect-src 'self'` blocked the cross-origin
+    // preview fetch outright, so an `/api/` url is now reduced to a path: the
+    // portal page's own origin answers it from the same backend.
     expect(sharePreviewPath('https://cdn.example.com/api/files/f1?sig=t', 'https://portal.example.com'))
-      .toBe('https://cdn.example.com/api/files/f1?sig=t&preview=1')
+      .toBe('/api/files/f1?sig=t&preview=1')
   })
 })

--- a/tests/unit/test_2733_portal_preview_same_origin.py
+++ b/tests/unit/test_2733_portal_preview_same_origin.py
@@ -1,0 +1,123 @@
+"""Portal file preview must not depend on the portal base URL's origin (#2733).
+
+A deployment may front its agents on a dedicated public hostname while the
+portal page is served from the app hostname. ``portal_documents`` then builds
+every ``download_url`` off that other origin, and the preview ``fetch()`` was
+blocked before it left the browser: CSP ``connect-src`` lists ``'self'`` plus
+two fixed hosts, and a per-deployment origin cannot be baked into a static
+nginx or Vite header.
+
+The fix is a same-origin rewrite in the loader, so what has to stay true is
+structural rather than textual:
+
+  - the preview fetch goes through ``sharePreviewPath``, which reduces an
+    ``/api/`` url to a path, instead of fetching ``download_url`` directly;
+  - Download keeps the absolute ``download_url``, an anchor navigation that
+    ``connect-src`` does not govern, so the shareable link is unaffected;
+  - the CSP stays static: no directive names a deployment-specific origin, so
+    nothing re-introduces the dependency this issue removed.
+
+Sibling of ``test_1400_csp_blob_preview.py``, which pins the ``blob:`` half of
+the same preview path.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+_FRONTEND = _ROOT / "src" / "frontend"
+_RAIL = _FRONTEND / "src" / "components" / "portal" / "PortalRailFiles.vue"
+_HELPERS = _FRONTEND / "src" / "components" / "portal" / "portalFiles.js"
+_NGINX_CONF = _FRONTEND / "security-headers.conf"
+_VITE_CONF = _FRONTEND / "vite.config.js"
+
+
+def _strip_comments(text: str) -> str:
+    """Drop /* */ and // runs so a prose mention cannot satisfy an assertion."""
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    return re.sub(r"(?m)^\s*//.*$", "", text)
+
+
+def _nginx_csp() -> str:
+    m = re.search(
+        r'add_header\s+Content-Security-Policy\s+"([^"]+)"', _NGINX_CONF.read_text()
+    )
+    assert m, "no Content-Security-Policy add_header in security-headers.conf"
+    return m.group(1)
+
+
+def _vite_csp() -> str:
+    m = re.search(
+        r"'Content-Security-Policy':(.*?)\n\}", _VITE_CONF.read_text(), re.DOTALL
+    )
+    assert m, "no Content-Security-Policy key in vite.config.js"
+    fragments = re.findall(r'"([^"]*)"', m.group(1))
+    assert fragments, "Content-Security-Policy value has no string literals"
+    return "".join(fragments)
+
+
+def test_preview_fetch_is_rewritten_to_the_page_origin():
+    """The rail previews through the rewrite, never straight off download_url."""
+    rail = _strip_comments(_RAIL.read_text())
+
+    assert "sharePreviewPath(" in rail, (
+        "the Files rail no longer previews through sharePreviewPath — a direct "
+        "fetch of an absolute download_url is what CSP connect-src blocks (#2733)"
+    )
+    # No parenthesis between `fetch(` and `download_url`: a call in between is
+    # the rewrite doing its job, a bare read is the bug this issue is about.
+    direct = re.findall(r"fetch\(\s*[^()]*download_url", rail)
+    assert direct == [], (
+        f"the preview fetch reads download_url directly: {direct}. On a "
+        "deployment whose portal base URL is another origin that request is "
+        "refused by connect-src before it is sent"
+    )
+
+
+def test_api_urls_are_reduced_to_a_path_whatever_origin_they_carry():
+    """The rewrite is bound to the backend's own routes, not to the origin."""
+    helpers = _strip_comments(_HELPERS.read_text())
+
+    assert "BACKEND_API_PREFIX" in helpers, (
+        "sameOriginPath no longer distinguishes the backend's own routes; an "
+        "/api/ url from another origin must still be reduced to a path (#2733)"
+    )
+    assert re.search(r"startsWith\(\s*BACKEND_API_PREFIX\s*\)", helpers), (
+        "the /api/ exemption in sameOriginPath is gone, so a cross-origin "
+        "download_url would be fetched cross-origin again"
+    )
+
+
+def test_download_keeps_the_absolute_url():
+    """Download is an anchor navigation, so the shareable link stays absolute."""
+    rail = _strip_comments(_RAIL.read_text())
+    assert re.search(r"\.href\s*=\s*row\.item\.download_url", rail), (
+        "the Download path no longer uses the absolute download_url — it is the "
+        "user-shareable link and saves natively through the anchor (#2733 AC 3)"
+    )
+
+
+@pytest.mark.parametrize("loader", [_nginx_csp, _vite_csp], ids=["nginx", "vite"])
+def test_csp_names_no_deployment_specific_origin(loader):
+    """The CSP stays a build-time constant.
+
+    The portal base URL is a runtime setting, so a template placeholder or an
+    interpolated origin in the header would be the wrong lever for preview and
+    would silently re-couple it to the deployment's hostname.
+    """
+    csp = loader()
+    for marker in ("${", "{{", "<PORTAL", "PORTAL_BASE_URL", "public_chat_url"):
+        assert marker not in csp, (
+            f"the CSP interpolates {marker!r} ({loader.__name__}): preview must "
+            "not depend on the portal base URL's origin being allowlisted (#2733)"
+        )
+    directives = {
+        part.split()[0]: set(part.split()[1:]) for part in csp.split(";") if part.split()
+    }
+    assert "'self'" in directives.get("connect-src", set()), (
+        f"connect-src no longer allows 'self' ({loader.__name__}), which is the "
+        "origin the preview fetch now targets"
+    )


### PR DESCRIPTION
## Description

The portal Files rail previewed a shared file by fetching `download_url`, which `portal_documents` builds off the resolved portal base URL. On a deployment that fronts agents on a dedicated public hostname, that url carries another origin than the portal page, so CSP `connect-src` refused the fetch before it was sent. Download kept working, being an anchor navigation.

`sameOriginPath` now reduces a url under `/api/` to `${pathname}${search}` even when its origin differs from the page's, so the preview fetch lands on the portal page's own origin and stays inside `connect-src 'self'`. That origin proxies `/api/*` to the same backend, and a share's authority is its `?sig=` token rather than the hostname the url was minted with, so the origin is decoration for these routes. Any other cross-origin url is still returned unchanged.

This is the frontend-only fix the issue names as preferred. Widening the CSP is not available: the portal base URL is a runtime setting and cannot be baked into a static nginx or Vite header.

## Related Issue

Fixes #2733

## Journey Impact

Journey Impact: none: the client portal's Files rail preview is not one of the eleven promises in `tests/journeys/catalog.yaml`. This restores an existing surface on a supported deployment topology and adds no user-facing capability.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Acceptance criteria

- **Preview works cross-origin, no `connect-src` violation.** The fetch target is now `/api/files/<id>?sig=…&preview=1`, same-origin by construction.
- **Same-origin, path and query only, whatever origin `download_url` carries.** `sharePreviewPath('https://files.example.com/api/files/f1?sig=t&download=1', 'https://app.example.com')` returns `/api/files/f1?sig=t&download=1&preview=1`. The `?sig=` token and `preview=1` survive, so the transfer still does not count as a download.
- **`download_url` unchanged.** Nothing in the diff touches `portal_documents` or the anchor path; `PortalRailFiles.vue` still assigns `a.href = row.item.download_url`, and a test pins that the string handed to `sharePreviewPath` is not mutated.
- **Client uploads unaffected.** They have no url and go through `portal.fetchUploadBlob`, which this diff does not touch.
- **No portal base URL configured keeps working.** A relative `download_url` was already reduced to a path and still is, pinned by its own case.
- **A unit test pins the behaviour.** Five cases in `portalFiles.spec.js` plus `tests/unit/test_2733_portal_preview_same_origin.py`, the sibling of `test_1400_csp_blob_preview.py`, which asserts that preview does not depend on the portal base URL's origin: the rail previews through the rewrite rather than off `download_url`, the `/api/` exemption exists, Download keeps the absolute url, and neither CSP interpolates a deployment-specific origin.
- **Regression note next to the `sameOriginPath` comment.** It said a portal base URL pointing elsewhere was "the deployment's problem"; it now records the topology as supported, with the issue number.

## Testing

- [x] I have tested this locally
- [x] New tests added (if applicable)
- [x] All existing tests pass

```
npx vitest run tests/unit/portalFiles.spec.js     # 56 passed
pytest tests/unit/test_2733_portal_preview_same_origin.py tests/unit/test_1400_csp_blob_preview.py   # 8 passed
```

Negative control: replacing the new condition with the old `if (crossOrigin) return raw` fails three vitest cases and the Python guard, so the tests hold the fix rather than the surroundings.

**One reversed assertion, called out rather than buried.** `portalFiles.spec.js` pinned the old behaviour twice, in `leaves a genuinely cross-origin url alone rather than pretending` and at the end of `marks full-blob previews without changing the download link or bearer token`. The first now uses a non-`/api/` url, which is where that rule still holds, and the second expects the path. Both carry a comment naming #2733, since the issue states this topology is supported rather than a misconfiguration.

**What I could not verify.** I have no deployment with a split portal hostname, so the browser half of AC 1 is not something I observed. The evidence here is the unit behaviour of the rewrite, the CSP guard, and the reading of `service.py::portal_documents` and `security-headers.conf` the issue lays out.

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation (if applicable) — bug fix, so a descriptive commit message per CONTRIBUTING
- [x] I have not committed any sensitive data (API keys, credentials, etc.)
- [x] I have added appropriate logging for new functionality — none added; this is a pure path rewrite
