### PR TITLE
fix(message_router): remove dead shadowed _sanitize_filename delegator

### DIFF
--- a/src/backend/adapters/message_router.py
+++ b/src/backend/adapters/message_router.py
@@ -33,7 +33,7 @@ from services.settings_service import settings_service
 from services.task_execution_service import get_task_execution_service
 from services.docker_utils import container_exec_run
 from services.telegram_media import process_voice
-from services.upload_service import process_file_uploads, format_file_size, sanitize_filename
+from services.upload_service import process_file_uploads, format_file_size
 from adapters.base import ChannelAdapter, ChannelResponse, FileAttachment, NormalizedMessage, OutboundFile
 
 logger = logging.getLogger(__name__)
@@ -304,10 +304,6 @@ def _check_rate_limit(key: str, max_msgs: Optional[int] = None, window: Optional
 
 def _format_file_size(size_bytes: int) -> str:
     return format_file_size(size_bytes)
-
-
-def _sanitize_filename(name: str, file_id: str, used_names: set) -> str:
-    return sanitize_filename(name, file_id, used_names)
 
 
 # Filename sanitization (Issue #487)


### PR DESCRIPTION
### What

`src/backend/adapters/message_router.py` defines `_sanitize_filename` **twice** at module scope:

- The first (lines ~309-310) is a one-line delegator to `services.upload_service.sanitize_filename`.
- The second (the block under `# Filename sanitization (Issue #487)`) is the full hardened implementation (NFKC normalize, basename, safe-char stripping, hidden-dotfile rejection, length cap, collision dedup).

Python binds the **later** definition, so the delegator is dead code. `pyflakes` flags it:

```
message_router.py:318:1: redefinition of unused '_sanitize_filename' from line 309
```

### Fix

Remove the dead delegator. Its only reference to the imported `sanitize_filename` symbol also disappears, so that name is dropped from the `services.upload_service` import.

**No behavior change** — the Issue #487 implementation is already the one that runs; this only deletes the unreachable earlier definition (and the now-unused import).

### Verification

`pyflakes` on the patched file no longer reports the redefinition, and `sanitize_filename` is no longer imported-but-unused. `+1 / -5`, one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
